### PR TITLE
feat(openai-agents): propagate response.metadata to spans and root

### DIFF
--- a/src/orq_ai_sdk/openai_agents_instrumentation/processor.py
+++ b/src/orq_ai_sdk/openai_agents_instrumentation/processor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from .constants import SpanAttributes, SpanKind
 
@@ -99,6 +99,11 @@ class EnhancedOpenAIAgentsProcessor(TracingProcessor):
         self._span_hierarchy: dict[str, str] = {}  # child_span_id -> parent_agent_span_id
         self._agent_inputs: Dict[str, Optional[SpanInputData]] = {}  # agent_span_id -> first LLM input
         self._agent_outputs: Dict[str, Optional[SpanOutputData]] = {}  # agent_span_id -> last LLM output
+        # User metadata captured from response.metadata on LLM calls. Cached
+        # per trace so we can bubble it onto the workflow root span at
+        # on_trace_end — Orq's traces-list Metadata column reads from the
+        # leading row, which is the root, not the LLM child.
+        self._trace_metadata: Dict[str, Dict[str, Any]] = {}
 
     def on_trace_start(self, trace: Trace) -> None:
         """Called when a trace is started."""
@@ -114,8 +119,26 @@ class EnhancedOpenAIAgentsProcessor(TracingProcessor):
     def on_trace_end(self, trace: Trace) -> None:
         """Called when a trace is finished."""
         if root_span := self._root_spans.pop(trace.trace_id, None):
+            metadata = self._trace_metadata.pop(trace.trace_id, None)
+            if metadata:
+                self._apply_metadata_attributes(root_span, metadata)
             root_span.set_status(Status(StatusCode.OK))
             root_span.end()
+        else:
+            self._trace_metadata.pop(trace.trace_id, None)
+
+    @staticmethod
+    def _apply_metadata_attributes(otel_span: OtelSpan, metadata: Dict[str, Any]) -> None:
+        for key, value in metadata.items():
+            if value is None:
+                continue
+            if isinstance(value, (str, bool, int, float)):
+                otel_span.set_attribute(f"metadata.{key}", value)
+            else:
+                try:
+                    otel_span.set_attribute(f"metadata.{key}", json.dumps(value))
+                except (TypeError, ValueError):
+                    otel_span.set_attribute(f"metadata.{key}", str(value))
 
     def on_span_start(self, span: Span[SpanData]) -> None:
         """Called when a span is started."""
@@ -173,7 +196,7 @@ class EnhancedOpenAIAgentsProcessor(TracingProcessor):
         if isinstance(data, AgentSpanData):
             self._handle_agent_span(otel_span, data, span.span_id)
         elif isinstance(data, ResponseSpanData):
-            self._handle_response_span(otel_span, data)
+            self._handle_response_span(otel_span, data, getattr(span, "trace_id", None))
             self._collect_agent_data(span.span_id, data, "input", "output")
         elif isinstance(data, GenerationSpanData):
             self._handle_generation_span(otel_span, data)
@@ -215,7 +238,7 @@ class EnhancedOpenAIAgentsProcessor(TracingProcessor):
         self._agent_inputs.pop(span_id, None)
         self._agent_outputs.pop(span_id, None)
 
-    def _handle_response_span(self, otel_span: OtelSpan, data: ResponseSpanData) -> None:
+    def _handle_response_span(self, otel_span: OtelSpan, data: ResponseSpanData, trace_id: Optional[str] = None) -> None:
         """Handle response span."""
         if hasattr(data, "response") and data.response:
             # Extract meaningful data from response instead of dumping the whole object
@@ -231,6 +254,18 @@ class EnhancedOpenAIAgentsProcessor(TracingProcessor):
             if hasattr(response, "model"):
                 otel_span.set_attribute(SpanAttributes.REQUEST_MODEL.value, response.model)
                 otel_span.set_attribute(SpanAttributes.RESPONSE_MODEL.value, response.model)
+
+            # Surface user metadata as flat `metadata.{key}` attributes so it
+            # lands on the genai_traces row and renders in Orq's traces list
+            # Metadata column. The OpenAI Responses API echoes the request's
+            # ModelSettings(metadata=...) back on response.metadata. We also
+            # cache it under the trace_id so on_trace_end can bubble it onto
+            # the workflow root span (the leading row in Orq's traces list).
+            metadata = getattr(response, "metadata", None)
+            if isinstance(metadata, dict) and metadata:
+                self._apply_metadata_attributes(otel_span, metadata)
+                if trace_id:
+                    self._trace_metadata.setdefault(trace_id, {}).update(metadata)
             
             # Extract and format output from response
             if hasattr(response, "output") and response.output:


### PR DESCRIPTION
## Summary

- Capture `response.metadata` on LLM response spans and emit each entry as a flat `metadata.{key}` attribute (with JSON fallback for non-scalar values)
- Cache metadata per `trace_id` and re-apply it onto the workflow root span at `on_trace_end`, so it appears on the leading row in Orq's traces list (where the Metadata column reads from)
- Thread `trace_id` through `_handle_response_span`

## Test plan

- [ ] Run an OpenAI Agents workflow with `ModelSettings(metadata={...})`
- [ ] Verify `metadata.{key}` attributes appear on the response span
- [ ] Verify metadata also bubbles onto the workflow root span and renders in the traces list Metadata column

🤖 Generated with [Claude Code](https://claude.com/claude-code)