### PR TITLE
fix(langchain): preserve tool_calls on LLM-end output

### DIFF
--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_async_handler.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_async_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
     extract_token_usage,
@@ -163,9 +164,19 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
                     if not content and event.streaming_tokens:
                         content = "".join(event.streaming_tokens)
 
+                    message: Dict[str, Any] = {
+                        "role": "assistant",
+                        "content": content,
+                    }
+                    tool_calls = extract_assistant_tool_calls(
+                        getattr(gen, "message", None),
+                    )
+                    if tool_calls:
+                        message["tool_calls"] = tool_calls
+
                     choices.append({
                         "index": idx,
-                        "message": {"role": "assistant", "content": content},
+                        "message": message,
                         "finish_reason": finish_reason,
                     })
             event.response_choices = choices

--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_handler.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
     extract_token_usage,
@@ -166,9 +167,19 @@ class OrqLangchainCallback(BaseCallbackHandler):
                     if not content and event.streaming_tokens:
                         content = "".join(event.streaming_tokens)
 
+                    message: Dict[str, Any] = {
+                        "role": "assistant",
+                        "content": content,
+                    }
+                    tool_calls = extract_assistant_tool_calls(
+                        getattr(gen, "message", None),
+                    )
+                    if tool_calls:
+                        message["tool_calls"] = tool_calls
+
                     choices.append({
                         "index": idx,
-                        "message": {"role": "assistant", "content": content},
+                        "message": message,
                         "finish_reason": finish_reason,
                     })
             event.response_choices = choices

--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_utils.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_utils.py
@@ -105,6 +105,24 @@ def normalize_messages(messages: List[List[Any]]) -> List[Dict[str, Any]]:
     return result
 
 
+def extract_assistant_tool_calls(message: Any) -> Optional[List[Any]]:
+    """Extract tool_calls from a LangChain message, supporting both OpenAI and LangChain shapes."""
+    if message is None:
+        return None
+
+    additional_kwargs = getattr(message, "additional_kwargs", None)
+    if isinstance(additional_kwargs, dict):
+        from_kwargs = additional_kwargs.get("tool_calls")
+        if isinstance(from_kwargs, list) and from_kwargs:
+            return from_kwargs
+
+    from_message = getattr(message, "tool_calls", None)
+    if isinstance(from_message, list) and from_message:
+        return from_message
+
+    return None
+
+
 def extract_token_usage(response: Any) -> Optional[Dict[str, Any]]:
     """Robustly extract token usage from LLMResult."""
     llm_output = getattr(response, "llm_output", None)

--- a/src/orq_ai_sdk/langchain/_async_handler.py
+++ b/src/orq_ai_sdk/langchain/_async_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
     extract_token_usage,
@@ -163,9 +164,19 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
                     if not content and event.streaming_tokens:
                         content = "".join(event.streaming_tokens)
 
+                    message: Dict[str, Any] = {
+                        "role": "assistant",
+                        "content": content,
+                    }
+                    tool_calls = extract_assistant_tool_calls(
+                        getattr(gen, "message", None),
+                    )
+                    if tool_calls:
+                        message["tool_calls"] = tool_calls
+
                     choices.append({
                         "index": idx,
-                        "message": {"role": "assistant", "content": content},
+                        "message": message,
                         "finish_reason": finish_reason,
                     })
             event.response_choices = choices

--- a/src/orq_ai_sdk/langchain/_handler.py
+++ b/src/orq_ai_sdk/langchain/_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
     extract_token_usage,
@@ -166,9 +167,19 @@ class OrqLangchainCallback(BaseCallbackHandler):
                     if not content and event.streaming_tokens:
                         content = "".join(event.streaming_tokens)
 
+                    message: Dict[str, Any] = {
+                        "role": "assistant",
+                        "content": content,
+                    }
+                    tool_calls = extract_assistant_tool_calls(
+                        getattr(gen, "message", None),
+                    )
+                    if tool_calls:
+                        message["tool_calls"] = tool_calls
+
                     choices.append({
                         "index": idx,
-                        "message": {"role": "assistant", "content": content},
+                        "message": message,
                         "finish_reason": finish_reason,
                     })
             event.response_choices = choices

--- a/src/orq_ai_sdk/langchain/_utils.py
+++ b/src/orq_ai_sdk/langchain/_utils.py
@@ -105,6 +105,24 @@ def normalize_messages(messages: List[List[Any]]) -> List[Dict[str, Any]]:
     return result
 
 
+def extract_assistant_tool_calls(message: Any) -> Optional[List[Any]]:
+    """Extract tool_calls from a LangChain message, supporting both OpenAI and LangChain shapes."""
+    if message is None:
+        return None
+
+    additional_kwargs = getattr(message, "additional_kwargs", None)
+    if isinstance(additional_kwargs, dict):
+        from_kwargs = additional_kwargs.get("tool_calls")
+        if isinstance(from_kwargs, list) and from_kwargs:
+            return from_kwargs
+
+    from_message = getattr(message, "tool_calls", None)
+    if isinstance(from_message, list) and from_message:
+        return from_message
+
+    return None
+
+
 def extract_token_usage(response: Any) -> Optional[Dict[str, Any]]:
     """Robustly extract token usage from LLMResult."""
     llm_output = getattr(response, "llm_output", None)


### PR DESCRIPTION
on_llm_end previously built choices[].message from gen.text only, dropping tool_calls when the model finished with finish_reason=tool_calls. Read them from gen.message.additional_kwargs.tool_calls (OpenAI shape) or gen.message.tool_calls (LangChain shape) and include on the message.

Mirrored across the sync and async callbacks in both src/orq_ai_sdk/langchain/ and packages/orq-rc/src/orq_ai_sdk/langchain/.