### PR TITLE
chore(orq-rc): allow input as redefined builtin in speakeasy gen

### DIFF
--- a/packages/orq-rc/.speakeasy/gen.yaml
+++ b/packages/orq-rc/.speakeasy/gen.yaml
@@ -42,6 +42,7 @@ python:
   allowedRedefinedBuiltins:
     - id
     - object
+    - input
   asyncMode: both
   authors:
     - Orq


### PR DESCRIPTION
- Add input to allowedRedefinedBuiltins in packages/orq-rc/.speakeasy/gen.yaml, bringing it in line with the root .speakeasy/gen.yaml config.