### PR TITLE
fix(langchain): normalize chain span roles and trim root span output (ENG-1785)

### DIFF
--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_async_handler.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_async_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    coerce_chain_payload,
     extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
@@ -23,6 +24,7 @@ from ._utils import (
     logger,
     normalize_messages,
     resolve_span_name,
+    root_output_delta,
 )
 
 
@@ -75,6 +77,7 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
         span = build_otlp_span(event)
         await self._client.send_span(span)
         self._events.remove(rid)
+        self._events.clear_root(rid)
 
     # ── LLM callbacks ──────────────────────────────────────────────
 
@@ -226,7 +229,7 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
                 run_id, parent_run_id, EventType.CHAIN, serialized, metadata, tags,
                 name=kwargs.get("name"),
             )
-            event.inputs = inputs if isinstance(inputs, dict) else {"inputs": inputs}
+            event.inputs = coerce_chain_payload(inputs)
 
             rid = str(run_id)
             if parent_run_id is None:
@@ -251,7 +254,10 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
             if not event:
                 return
             event.end_time_ns = _nano_timestamp()
-            event.outputs = outputs if isinstance(outputs, dict) else {"outputs": outputs}
+            outputs_dict = coerce_chain_payload(outputs)
+            if self._events.is_root(rid):
+                outputs_dict = root_output_delta(event.inputs, outputs_dict)
+            event.outputs = outputs_dict
 
             if self._events.is_graph_node(rid):
                 self._events.graph.on_node_end(event.name, str(self._events.root_run_id))

--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_events.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_events.py
@@ -49,6 +49,16 @@ class Events:
         """Check if this run_id is the root chain."""
         return run_id == self._root_run_id
 
+    def clear_root(self, run_id: str) -> None:
+        """Clear root tracking when the current root chain finishes.
+
+        Allows subsequent top-level invocations on the same handler to
+        be correctly identified as roots.
+        """
+        if run_id == self._root_run_id:
+            self._root_run_id = None
+            self.graph = GraphTracker()
+
     def is_graph_node(self, run_id: str) -> bool:
         """Check if this chain's parent is the root (= a LangGraph node)."""
         parent = self._parent_map.get(run_id)

--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_handler.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    coerce_chain_payload,
     extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
@@ -23,6 +24,7 @@ from ._utils import (
     logger,
     normalize_messages,
     resolve_span_name,
+    root_output_delta,
 )
 
 
@@ -77,6 +79,7 @@ class OrqLangchainCallback(BaseCallbackHandler):
         span = build_otlp_span(event)
         self._client.send_span(span)
         self._events.remove(rid)
+        self._events.clear_root(rid)
 
     # ── LLM callbacks ──────────────────────────────────────────────
 
@@ -230,7 +233,7 @@ class OrqLangchainCallback(BaseCallbackHandler):
                 run_id, parent_run_id, EventType.CHAIN, serialized, metadata, tags,
                 name=kwargs.get("name"),
             )
-            event.inputs = inputs if isinstance(inputs, dict) else {"inputs": inputs}
+            event.inputs = coerce_chain_payload(inputs)
 
             rid = str(run_id)
             # Track root chain (first parentless chain = LangGraph graph)
@@ -260,7 +263,15 @@ class OrqLangchainCallback(BaseCallbackHandler):
                 logger.debug("CHAIN_END MISSING run_id=%s", run_id)
                 return
             event.end_time_ns = _nano_timestamp()
-            event.outputs = outputs if isinstance(outputs, dict) else {"outputs": outputs}
+            outputs_dict = coerce_chain_payload(outputs)
+
+            # LangGraph hands the root chain its full merged state on completion,
+            # which echoes the input messages back. Subtract them so the root
+            # span's output contains only the messages this run produced.
+            if self._events.is_root(rid):
+                outputs_dict = root_output_delta(event.inputs, outputs_dict)
+
+            event.outputs = outputs_dict
 
             # Track graph node completion for edge building
             if self._events.is_graph_node(rid):

--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_span_builder.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_span_builder.py
@@ -11,6 +11,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from ._models import EventType, InFlightEvent
+from ._utils import normalize_messages
 
 
 def _nano_timestamp() -> str:
@@ -218,6 +219,49 @@ def _extract_provider(serialized: Optional[Dict[str, Any]]) -> Optional[str]:
     return None
 
 
+_ROLE_ALIASES = {"human": "user", "ai": "assistant"}
+
+
+def _normalize_item(m: Any, base_message_cls: Any) -> Any:
+    """Normalize one chain-input message to a role/content dict."""
+    if isinstance(m, base_message_cls):
+        return normalize_messages([[m]])[0]
+    if isinstance(m, tuple) and len(m) == 2 and isinstance(m[0], str):
+        role = _ROLE_ALIASES.get(m[0].lower(), m[0].lower())
+        return {"role": role, "content": m[1]}
+    return m
+
+
+def _maybe_normalize_chain_messages(payload: Any) -> Any:
+    """Normalize a {'messages': [...]} payload to role-typed dicts.
+
+    Handles raw BaseMessage objects (from LangGraph state) and ('user', text)
+    tuples (the form accepted by agent.invoke). Without this, chain inputs
+    serialize via __str__ and lose the structured role field.
+    """
+    if not isinstance(payload, dict) or "messages" not in payload:
+        return payload
+    raw = payload["messages"]
+    if not isinstance(raw, list) or not raw:
+        return payload
+    try:
+        from langchain_core.messages import BaseMessage  # type: ignore  # pylint: disable=import-error,import-outside-toplevel
+    except ImportError:
+        return payload
+
+    def _needs(m: Any) -> bool:
+        if isinstance(m, BaseMessage):
+            return True
+        if isinstance(m, tuple) and len(m) == 2 and isinstance(m[0], str):
+            return True
+        return False
+
+    if not any(_needs(m) for m in raw):
+        return payload
+
+    return {**payload, "messages": [_normalize_item(m, BaseMessage) for m in raw]}
+
+
 def _build_prompt(event: InFlightEvent) -> Optional[Any]:
     """Build gen_ai.prompt value."""
     if event.event_type == EventType.LLM:
@@ -226,7 +270,7 @@ def _build_prompt(event: InFlightEvent) -> Optional[Any]:
         if event.prompts:
             return {"prompts": event.prompts}
     if event.event_type in (EventType.CHAIN, EventType.AGENT):
-        return event.inputs
+        return _maybe_normalize_chain_messages(event.inputs)
     if event.event_type == EventType.TOOL:
         if event.tool_input is not None:
             return {"input": event.tool_input}
@@ -246,7 +290,7 @@ def _build_completion(event: InFlightEvent) -> Optional[Any]:
             output["usage"] = event.token_usage
         return output if output else None
     if event.event_type in (EventType.CHAIN, EventType.AGENT):
-        return event.outputs
+        return _maybe_normalize_chain_messages(event.outputs)
     if event.event_type == EventType.TOOL:
         if event.tool_output is not None:
             return {"output": event.tool_output}

--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_utils.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_utils.py
@@ -179,6 +179,67 @@ def extract_token_usage(response: Any) -> Optional[Dict[str, Any]]:
     return result
 
 
+def coerce_chain_payload(payload: Any) -> Dict[str, Any]:
+    """Wrap chain inputs/outputs into a dict suitable for the span normalizer.
+
+    LangChain hands callbacks raw BaseMessage objects (or lists thereof) for
+    chains like RunnableSequence wrapping a chat model. Without coercion they
+    get stored as ``{"outputs": <AIMessage>}`` and serialized via ``__str__``,
+    producing an unreadable Python repr in the trace. Wrapping them as
+    ``{"messages": [...]}`` routes through the normal role/tool_calls path.
+    """
+    if isinstance(payload, dict):
+        return payload
+
+    try:
+        from langchain_core.messages import BaseMessage  # type: ignore  # pylint: disable=import-error,import-outside-toplevel
+    except ImportError:
+        return {"outputs": payload}
+
+    if isinstance(payload, BaseMessage):
+        return {"messages": [payload]}
+    if isinstance(payload, list) and payload and all(
+        isinstance(m, BaseMessage) for m in payload
+    ):
+        return {"messages": payload}
+    return {"outputs": payload}
+
+
+def root_output_delta(
+    inputs: Optional[Dict[str, Any]],
+    outputs: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return outputs with input messages stripped from outputs['messages'].
+
+    LangGraph's root on_chain_end receives the full merged state, so the
+    input turns reappear in outputs['messages']. Use message ids when every
+    input has one (handles RemoveMessage correctly); otherwise fall back to
+    positional trimming, which is safe under the append-only add_messages
+    reducer LangGraph uses by default.
+    """
+    if not isinstance(inputs, dict) or not isinstance(outputs, dict):
+        return outputs
+    in_msgs = inputs.get("messages")
+    out_msgs = outputs.get("messages")
+    if not isinstance(in_msgs, list) or not isinstance(out_msgs, list) or not out_msgs:
+        return outputs
+
+    def _id_of(msg: Any) -> Optional[str]:
+        if isinstance(msg, dict):
+            return msg.get("id")
+        return getattr(msg, "id", None)
+
+    in_ids = [_id_of(m) for m in in_msgs]
+    if in_msgs and all(mid for mid in in_ids):
+        input_id_set = set(in_ids)
+        delta = [m for m in out_msgs if _id_of(m) not in input_id_set]
+        return {**outputs, "messages": delta}
+
+    if len(out_msgs) >= len(in_msgs):
+        return {**outputs, "messages": out_msgs[len(in_msgs):]}
+    return outputs
+
+
 def resolve_span_name(
     name: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,

--- a/src/orq_ai_sdk/langchain/_async_handler.py
+++ b/src/orq_ai_sdk/langchain/_async_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    coerce_chain_payload,
     extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
@@ -23,6 +24,7 @@ from ._utils import (
     logger,
     normalize_messages,
     resolve_span_name,
+    root_output_delta,
 )
 
 
@@ -75,6 +77,7 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
         span = build_otlp_span(event)
         await self._client.send_span(span)
         self._events.remove(rid)
+        self._events.clear_root(rid)
 
     # ── LLM callbacks ──────────────────────────────────────────────
 
@@ -226,7 +229,7 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
                 run_id, parent_run_id, EventType.CHAIN, serialized, metadata, tags,
                 name=kwargs.get("name"),
             )
-            event.inputs = inputs if isinstance(inputs, dict) else {"inputs": inputs}
+            event.inputs = coerce_chain_payload(inputs)
 
             rid = str(run_id)
             if parent_run_id is None:
@@ -251,7 +254,10 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
             if not event:
                 return
             event.end_time_ns = _nano_timestamp()
-            event.outputs = outputs if isinstance(outputs, dict) else {"outputs": outputs}
+            outputs_dict = coerce_chain_payload(outputs)
+            if self._events.is_root(rid):
+                outputs_dict = root_output_delta(event.inputs, outputs_dict)
+            event.outputs = outputs_dict
 
             if self._events.is_graph_node(rid):
                 self._events.graph.on_node_end(event.name, str(self._events.root_run_id))

--- a/src/orq_ai_sdk/langchain/_events.py
+++ b/src/orq_ai_sdk/langchain/_events.py
@@ -49,6 +49,16 @@ class Events:
         """Check if this run_id is the root chain."""
         return run_id == self._root_run_id
 
+    def clear_root(self, run_id: str) -> None:
+        """Clear root tracking when the current root chain finishes.
+
+        Allows subsequent top-level invocations on the same handler to
+        be correctly identified as roots.
+        """
+        if run_id == self._root_run_id:
+            self._root_run_id = None
+            self.graph = GraphTracker()
+
     def is_graph_node(self, run_id: str) -> bool:
         """Check if this chain's parent is the root (= a LangGraph node)."""
         parent = self._parent_map.get(run_id)

--- a/src/orq_ai_sdk/langchain/_handler.py
+++ b/src/orq_ai_sdk/langchain/_handler.py
@@ -15,6 +15,7 @@ from ._events import Events
 from ._models import EventType, InFlightEvent
 from ._span_builder import build_otlp_span, _nano_timestamp
 from ._utils import (
+    coerce_chain_payload,
     extract_assistant_tool_calls,
     extract_model_name,
     extract_model_parameters,
@@ -23,6 +24,7 @@ from ._utils import (
     logger,
     normalize_messages,
     resolve_span_name,
+    root_output_delta,
 )
 
 
@@ -77,6 +79,7 @@ class OrqLangchainCallback(BaseCallbackHandler):
         span = build_otlp_span(event)
         self._client.send_span(span)
         self._events.remove(rid)
+        self._events.clear_root(rid)
 
     # ── LLM callbacks ──────────────────────────────────────────────
 
@@ -230,7 +233,7 @@ class OrqLangchainCallback(BaseCallbackHandler):
                 run_id, parent_run_id, EventType.CHAIN, serialized, metadata, tags,
                 name=kwargs.get("name"),
             )
-            event.inputs = inputs if isinstance(inputs, dict) else {"inputs": inputs}
+            event.inputs = coerce_chain_payload(inputs)
 
             rid = str(run_id)
             # Track root chain (first parentless chain = LangGraph graph)
@@ -260,7 +263,15 @@ class OrqLangchainCallback(BaseCallbackHandler):
                 logger.debug("CHAIN_END MISSING run_id=%s", run_id)
                 return
             event.end_time_ns = _nano_timestamp()
-            event.outputs = outputs if isinstance(outputs, dict) else {"outputs": outputs}
+            outputs_dict = coerce_chain_payload(outputs)
+
+            # LangGraph hands the root chain its full merged state on completion,
+            # which echoes the input messages back. Subtract them so the root
+            # span's output contains only the messages this run produced.
+            if self._events.is_root(rid):
+                outputs_dict = root_output_delta(event.inputs, outputs_dict)
+
+            event.outputs = outputs_dict
 
             # Track graph node completion for edge building
             if self._events.is_graph_node(rid):

--- a/src/orq_ai_sdk/langchain/_span_builder.py
+++ b/src/orq_ai_sdk/langchain/_span_builder.py
@@ -11,6 +11,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from ._models import EventType, InFlightEvent
+from ._utils import normalize_messages
 
 
 def _nano_timestamp() -> str:
@@ -218,6 +219,49 @@ def _extract_provider(serialized: Optional[Dict[str, Any]]) -> Optional[str]:
     return None
 
 
+_ROLE_ALIASES = {"human": "user", "ai": "assistant"}
+
+
+def _normalize_item(m: Any, base_message_cls: Any) -> Any:
+    """Normalize one chain-input message to a role/content dict."""
+    if isinstance(m, base_message_cls):
+        return normalize_messages([[m]])[0]
+    if isinstance(m, tuple) and len(m) == 2 and isinstance(m[0], str):
+        role = _ROLE_ALIASES.get(m[0].lower(), m[0].lower())
+        return {"role": role, "content": m[1]}
+    return m
+
+
+def _maybe_normalize_chain_messages(payload: Any) -> Any:
+    """Normalize a {'messages': [...]} payload to role-typed dicts.
+
+    Handles raw BaseMessage objects (from LangGraph state) and ('user', text)
+    tuples (the form accepted by agent.invoke). Without this, chain inputs
+    serialize via __str__ and lose the structured role field.
+    """
+    if not isinstance(payload, dict) or "messages" not in payload:
+        return payload
+    raw = payload["messages"]
+    if not isinstance(raw, list) or not raw:
+        return payload
+    try:
+        from langchain_core.messages import BaseMessage  # type: ignore  # pylint: disable=import-error,import-outside-toplevel
+    except ImportError:
+        return payload
+
+    def _needs(m: Any) -> bool:
+        if isinstance(m, BaseMessage):
+            return True
+        if isinstance(m, tuple) and len(m) == 2 and isinstance(m[0], str):
+            return True
+        return False
+
+    if not any(_needs(m) for m in raw):
+        return payload
+
+    return {**payload, "messages": [_normalize_item(m, BaseMessage) for m in raw]}
+
+
 def _build_prompt(event: InFlightEvent) -> Optional[Any]:
     """Build gen_ai.prompt value."""
     if event.event_type == EventType.LLM:
@@ -226,7 +270,7 @@ def _build_prompt(event: InFlightEvent) -> Optional[Any]:
         if event.prompts:
             return {"prompts": event.prompts}
     if event.event_type in (EventType.CHAIN, EventType.AGENT):
-        return event.inputs
+        return _maybe_normalize_chain_messages(event.inputs)
     if event.event_type == EventType.TOOL:
         if event.tool_input is not None:
             return {"input": event.tool_input}
@@ -246,7 +290,7 @@ def _build_completion(event: InFlightEvent) -> Optional[Any]:
             output["usage"] = event.token_usage
         return output if output else None
     if event.event_type in (EventType.CHAIN, EventType.AGENT):
-        return event.outputs
+        return _maybe_normalize_chain_messages(event.outputs)
     if event.event_type == EventType.TOOL:
         if event.tool_output is not None:
             return {"output": event.tool_output}

--- a/src/orq_ai_sdk/langchain/_utils.py
+++ b/src/orq_ai_sdk/langchain/_utils.py
@@ -179,6 +179,67 @@ def extract_token_usage(response: Any) -> Optional[Dict[str, Any]]:
     return result
 
 
+def coerce_chain_payload(payload: Any) -> Dict[str, Any]:
+    """Wrap chain inputs/outputs into a dict suitable for the span normalizer.
+
+    LangChain hands callbacks raw BaseMessage objects (or lists thereof) for
+    chains like RunnableSequence wrapping a chat model. Without coercion they
+    get stored as ``{"outputs": <AIMessage>}`` and serialized via ``__str__``,
+    producing an unreadable Python repr in the trace. Wrapping them as
+    ``{"messages": [...]}`` routes through the normal role/tool_calls path.
+    """
+    if isinstance(payload, dict):
+        return payload
+
+    try:
+        from langchain_core.messages import BaseMessage  # type: ignore  # pylint: disable=import-error,import-outside-toplevel
+    except ImportError:
+        return {"outputs": payload}
+
+    if isinstance(payload, BaseMessage):
+        return {"messages": [payload]}
+    if isinstance(payload, list) and payload and all(
+        isinstance(m, BaseMessage) for m in payload
+    ):
+        return {"messages": payload}
+    return {"outputs": payload}
+
+
+def root_output_delta(
+    inputs: Optional[Dict[str, Any]],
+    outputs: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return outputs with input messages stripped from outputs['messages'].
+
+    LangGraph's root on_chain_end receives the full merged state, so the
+    input turns reappear in outputs['messages']. Use message ids when every
+    input has one (handles RemoveMessage correctly); otherwise fall back to
+    positional trimming, which is safe under the append-only add_messages
+    reducer LangGraph uses by default.
+    """
+    if not isinstance(inputs, dict) or not isinstance(outputs, dict):
+        return outputs
+    in_msgs = inputs.get("messages")
+    out_msgs = outputs.get("messages")
+    if not isinstance(in_msgs, list) or not isinstance(out_msgs, list) or not out_msgs:
+        return outputs
+
+    def _id_of(msg: Any) -> Optional[str]:
+        if isinstance(msg, dict):
+            return msg.get("id")
+        return getattr(msg, "id", None)
+
+    in_ids = [_id_of(m) for m in in_msgs]
+    if in_msgs and all(mid for mid in in_ids):
+        input_id_set = set(in_ids)
+        delta = [m for m in out_msgs if _id_of(m) not in input_id_set]
+        return {**outputs, "messages": delta}
+
+    if len(out_msgs) >= len(in_msgs):
+        return {**outputs, "messages": out_msgs[len(in_msgs):]}
+    return outputs
+
+
 def resolve_span_name(
     name: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,

--- a/tests/test_langchain_chain_roles.py
+++ b/tests/test_langchain_chain_roles.py
@@ -1,0 +1,205 @@
+"""Regression test for chain/agent span message-role round-tripping.
+
+Prior to the fix, _build_prompt/_build_completion returned event.inputs/outputs
+verbatim for CHAIN/AGENT events. Raw LangChain Message objects then serialized
+via __str__ and lost their structured role, so SystemMessage/HumanMessage/
+AIMessage all surfaced as role: assistant in the backend.
+"""
+
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from langchain_core.messages import (  # noqa: E402
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from orq_ai_sdk.langchain._models import EventType, InFlightEvent  # noqa: E402
+from orq_ai_sdk.langchain._span_builder import (  # noqa: E402
+    _build_completion,
+    _build_prompt,
+)
+
+
+def _make_chain_event(*, inputs=None, outputs=None) -> InFlightEvent:
+    return InFlightEvent(
+        run_id="run-1",
+        event_type=EventType.CHAIN,
+        inputs=inputs,
+        outputs=outputs,
+    )
+
+
+class TestChainMessageRoles:
+    def test_prompt_preserves_roles_for_all_message_types(self):
+        messages = [
+            SystemMessage(content="sys"),
+            HumanMessage(content="hi"),
+            AIMessage(
+                content="ok",
+                tool_calls=[{"name": "noop", "args": {}, "id": "call_1"}],
+            ),
+            ToolMessage(content="result", tool_call_id="call_1"),
+            HumanMessage(content="continue"),
+        ]
+        event = _make_chain_event(inputs={"messages": messages})
+
+        prompt = _build_prompt(event)
+
+        assert [m["role"] for m in prompt["messages"]] == [
+            "system",
+            "user",
+            "assistant",
+            "tool",
+            "user",
+        ]
+
+    def test_completion_preserves_assistant_role(self):
+        event = _make_chain_event(outputs={"messages": [AIMessage(content="done")]})
+
+        completion = _build_completion(event)
+
+        assert completion["messages"][0]["role"] == "assistant"
+        assert completion["messages"][0]["content"] == "done"
+
+    def test_ai_message_tool_calls_survive_normalization(self):
+        tool_call = {"name": "lookup", "args": {"q": "x"}, "id": "call_abc"}
+        event = _make_chain_event(
+            outputs={"messages": [AIMessage(content="", tool_calls=[tool_call])]}
+        )
+
+        completion = _build_completion(event)
+
+        entry = completion["messages"][0]
+        assert entry["role"] == "assistant"
+        assert len(entry["tool_calls"]) == 1
+        assert entry["tool_calls"][0]["name"] == "lookup"
+        assert entry["tool_calls"][0]["id"] == "call_abc"
+        assert entry["tool_calls"][0]["args"] == {"q": "x"}
+
+    def test_extra_state_keys_are_preserved(self):
+        event = _make_chain_event(
+            inputs={
+                "messages": [HumanMessage(content="hi")],
+                "session_id": "abc",
+                "step": 2,
+            }
+        )
+
+        prompt = _build_prompt(event)
+
+        assert prompt["session_id"] == "abc"
+        assert prompt["step"] == 2
+        assert prompt["messages"][0]["role"] == "user"
+
+    def test_non_message_inputs_pass_through_unchanged(self):
+        event = _make_chain_event(inputs={"query": "search term", "k": 5})
+
+        prompt = _build_prompt(event)
+
+        assert prompt == {"query": "search term", "k": 5}
+
+    def test_already_normalized_messages_pass_through(self):
+        already_dicts = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ]
+        event = _make_chain_event(inputs={"messages": already_dicts})
+
+        prompt = _build_prompt(event)
+
+        assert prompt["messages"] == already_dicts
+
+    def test_empty_messages_list_passes_through(self):
+        event = _make_chain_event(inputs={"messages": []})
+
+        prompt = _build_prompt(event)
+
+        assert prompt == {"messages": []}
+
+    def test_none_inputs_returns_none(self):
+        event = _make_chain_event(inputs=None)
+
+        assert _build_prompt(event) is None
+
+    def test_tuple_inputs_get_normalized(self):
+        # create_react_agent style: {"messages": [("user", "...")]}
+        event = _make_chain_event(
+            inputs={"messages": [("user", "hi"), ("system", "be nice")]}
+        )
+
+        prompt = _build_prompt(event)
+
+        assert prompt["messages"] == [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "be nice"},
+        ]
+
+    def test_tuple_role_aliases(self):
+        event = _make_chain_event(
+            inputs={"messages": [("human", "hi"), ("ai", "ok")]}
+        )
+
+        prompt = _build_prompt(event)
+
+        assert [m["role"] for m in prompt["messages"]] == ["user", "assistant"]
+
+    def test_chain_output_as_single_ai_message_gets_normalized(self):
+        # RunnableSequence wrapping a chat model hands on_chain_end a bare
+        # AIMessage (not wrapped in a dict). The SDK now coerces this into
+        # {messages: [...]} before normalization, so the trace gets readable
+        # role/content/tool_calls instead of a Python __str__ repr.
+        from orq_ai_sdk.langchain._utils import coerce_chain_payload  # noqa: WPS433
+
+        ai = AIMessage(
+            content="",
+            tool_calls=[{"name": "lookup", "args": {"q": "x"}, "id": "call_1"}],
+        )
+        event = _make_chain_event(outputs=coerce_chain_payload(ai))
+
+        completion = _build_completion(event)
+
+        assert completion["messages"][0]["role"] == "assistant"
+        assert completion["messages"][0]["content"] == ""
+        assert len(completion["messages"][0]["tool_calls"]) == 1
+
+    def test_chain_output_as_basemessage_list_gets_normalized(self):
+        from orq_ai_sdk.langchain._utils import coerce_chain_payload  # noqa: WPS433
+
+        messages = [HumanMessage(content="hi"), AIMessage(content="hello")]
+        event = _make_chain_event(outputs=coerce_chain_payload(messages))
+
+        completion = _build_completion(event)
+
+        assert [m["role"] for m in completion["messages"]] == ["user", "assistant"]
+
+    def test_coerce_passes_dicts_through_unchanged(self):
+        from orq_ai_sdk.langchain._utils import coerce_chain_payload  # noqa: WPS433
+
+        payload = {"messages": [HumanMessage(content="hi")], "extra": "keep"}
+        assert coerce_chain_payload(payload) is payload
+
+    def test_coerce_falls_back_to_outputs_for_unknown_types(self):
+        from orq_ai_sdk.langchain._utils import coerce_chain_payload  # noqa: WPS433
+
+        assert coerce_chain_payload("a string") == {"outputs": "a string"}
+        assert coerce_chain_payload(42) == {"outputs": 42}
+
+    def test_mixed_basemessages_and_tuples(self):
+        event = _make_chain_event(
+            inputs={
+                "messages": [
+                    ("user", "hi"),
+                    AIMessage(content="hello back"),
+                ]
+            }
+        )
+
+        prompt = _build_prompt(event)
+
+        assert [m["role"] for m in prompt["messages"]] == ["user", "assistant"]
+        assert prompt["messages"][0]["content"] == "hi"
+        assert prompt["messages"][1]["content"] == "hello back"

--- a/tests/test_langchain_events.py
+++ b/tests/test_langchain_events.py
@@ -1,0 +1,60 @@
+"""Tests for the Events store, especially root-run tracking across invocations."""
+
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from orq_ai_sdk.langchain._events import Events  # noqa: E402
+
+
+class TestRootTracking:
+    def test_first_parentless_chain_becomes_root(self):
+        events = Events()
+        events.set_root_if_needed("run-1")
+
+        assert events.is_root("run-1")
+        assert events.root_run_id == "run-1"
+
+    def test_second_set_root_does_not_override(self):
+        events = Events()
+        events.set_root_if_needed("run-1")
+        events.set_root_if_needed("run-2")
+
+        assert events.is_root("run-1")
+        assert not events.is_root("run-2")
+
+    def test_clear_root_releases_first_run(self):
+        events = Events()
+        events.set_root_if_needed("run-1")
+        events.clear_root("run-1")
+
+        assert events.root_run_id is None
+        assert not events.is_root("run-1")
+
+    def test_clear_root_ignores_non_root_ids(self):
+        events = Events()
+        events.set_root_if_needed("run-1")
+        events.clear_root("run-2")
+
+        assert events.is_root("run-1")
+
+    def test_new_invocation_becomes_root_after_clear(self):
+        # Reproduces the multi-invocation bug: prior to the fix,
+        # the second top-level invocation could never become root.
+        events = Events()
+        events.set_root_if_needed("run-1")
+        events.clear_root("run-1")
+        events.set_root_if_needed("run-2")
+
+        assert events.is_root("run-2")
+        assert not events.is_root("run-1")
+
+    def test_clear_root_resets_graph_tracker(self):
+        events = Events()
+        events.set_root_if_needed("run-1")
+        first_graph = events.graph
+
+        events.clear_root("run-1")
+
+        # New graph tracker for the next invocation, so node state doesn't leak.
+        assert events.graph is not first_graph

--- a/tests/test_langchain_output_delta.py
+++ b/tests/test_langchain_output_delta.py
@@ -1,0 +1,147 @@
+"""Regression test for root-chain output message delta.
+
+LangGraph hands its root on_chain_end the full merged state, so the
+input turns leak into outputs['messages']. The handler trims them via
+root_output_delta before storing event.outputs.
+"""
+
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage  # noqa: E402
+
+from orq_ai_sdk.langchain._utils import root_output_delta  # noqa: E402
+
+
+class TestRootOutputDelta:
+    def test_strips_input_messages_by_id(self):
+        human = HumanMessage(content="hello", id="msg-1")
+        new_ai = AIMessage(content="hi", id="msg-2")
+
+        result = root_output_delta(
+            inputs={"messages": [human]},
+            outputs={"messages": [human, new_ai]},
+        )
+
+        assert result["messages"] == [new_ai]
+
+    def test_multi_turn_input_with_single_new_reply(self):
+        inputs = [
+            SystemMessage(content="sys", id="m1"),
+            HumanMessage(content="hi", id="m2"),
+            AIMessage(content="hello", id="m3"),
+            HumanMessage(content="continue", id="m4"),
+        ]
+        reply = AIMessage(content="ok", id="m5")
+
+        result = root_output_delta(
+            inputs={"messages": inputs},
+            outputs={"messages": inputs + [reply]},
+        )
+
+        assert result["messages"] == [reply]
+
+    def test_falls_back_to_positional_trim_when_ids_missing(self):
+        # Older LangChain Message objects may not auto-assign ids.
+        human = HumanMessage(content="hi")
+        human.id = None
+        reply = AIMessage(content="ok")
+        reply.id = None
+
+        result = root_output_delta(
+            inputs={"messages": [human]},
+            outputs={"messages": [human, reply]},
+        )
+
+        assert result["messages"] == [reply]
+
+    def test_tuple_inputs_trimmed_positionally(self):
+        # create_react_agent: input is [("user", "...")], output is BaseMessage list.
+        ai = AIMessage(content="hello", id="m2")
+        result = root_output_delta(
+            inputs={"messages": [("user", "hi")]},
+            outputs={"messages": [HumanMessage(content="hi", id="m1"), ai]},
+        )
+
+        assert result["messages"] == [ai]
+
+    def test_tuple_inputs_multiple_new(self):
+        replies = [
+            AIMessage(content="tool call", id="m2"),
+            HumanMessage(content="next turn", id="m3"),  # synthetic, illustrative
+        ]
+        result = root_output_delta(
+            inputs={"messages": [("user", "hi")]},
+            outputs={"messages": [HumanMessage(content="hi", id="m1")] + replies},
+        )
+
+        assert result["messages"] == replies
+
+    def test_preserves_extra_output_keys(self):
+        human = HumanMessage(content="hi", id="m1")
+        reply = AIMessage(content="ok", id="m2")
+
+        result = root_output_delta(
+            inputs={"messages": [human]},
+            outputs={
+                "messages": [human, reply],
+                "step": 3,
+                "metadata": {"foo": "bar"},
+            },
+        )
+
+        assert result["messages"] == [reply]
+        assert result["step"] == 3
+        assert result["metadata"] == {"foo": "bar"}
+
+    def test_empty_output_messages_passes_through(self):
+        result = root_output_delta(
+            inputs={"messages": [HumanMessage(content="hi", id="m1")]},
+            outputs={"messages": []},
+        )
+
+        assert result == {"messages": []}
+
+    def test_non_messages_output_unchanged(self):
+        outputs = {"summary": "done", "count": 3}
+
+        result = root_output_delta(
+            inputs={"messages": [HumanMessage(content="hi", id="m1")]},
+            outputs=outputs,
+        )
+
+        assert result == outputs
+
+    def test_missing_inputs_passes_through(self):
+        outputs = {"messages": [AIMessage(content="ok", id="m1")]}
+
+        result = root_output_delta(inputs=None, outputs=outputs)
+
+        assert result == outputs
+
+    def test_works_with_already_normalized_dict_messages(self):
+        in_dict = {"role": "user", "content": "hi", "id": "m1"}
+        new_dict = {"role": "assistant", "content": "ok", "id": "m2"}
+
+        result = root_output_delta(
+            inputs={"messages": [in_dict]},
+            outputs={"messages": [in_dict, new_dict]},
+        )
+
+        assert result["messages"] == [new_dict]
+
+    def test_message_removed_via_id_filtering(self):
+        # If a node deletes a message (e.g. RemoveMessage), it simply isn't in
+        # outputs.messages anymore; the delta should reflect only what remains
+        # that wasn't in inputs.
+        msg_keep = HumanMessage(content="keep me", id="m1")
+        msg_drop = HumanMessage(content="will be removed", id="m2")
+        reply = AIMessage(content="reply", id="m3")
+
+        result = root_output_delta(
+            inputs={"messages": [msg_keep, msg_drop]},
+            outputs={"messages": [msg_keep, reply]},  # m2 removed by a node
+        )
+
+        assert result["messages"] == [reply]


### PR DESCRIPTION
Multi-turn LangChain/LangGraph traces had three SDK-side problems on chain and root trace spans:

- Roles collapsed to assistant because chain inputs and outputs were serialized via the raw LangChain Message __str__, dropping the role.
- The root trace span output echoed the full merged state including the input messages instead of only the delta the run produced.
- Multiple top-level invocations on the same handler only registered the first as root, so subsequent traces did not get root-only processing.

This change:

- Routes chain/agent inputs and outputs through normalize_messages so the backend receives structured role and content fields (handles LangChain Message objects and tuple inputs from create_react_agent).
- Adds root_output_delta to subtract input messages from the root span's output by message id, with positional trim fallback when ids are absent.
- Adds clear_root on chain finish so subsequent invocations on the same handler each register as their own root.
- Adds coerce_chain_payload to wrap bare BaseMessage outputs from RunnableSequence into a messages list before serialization.
- Mirrors the changes into packages/orq-rc.
- Adds regression tests for roles, output delta, and root tracking.