### PR TITLE
fix(langchain): use getattr to unwrap ToolMessage content

### DIFF
--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_async_handler.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_async_handler.py
@@ -342,7 +342,7 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
             # letting non-message Pydantic returns serialize structurally.
             unwrapped: Any = output
             if isinstance(output, BaseMessage):
-                unwrapped = output.content
+                unwrapped = getattr(output, "content", output)
             event.tool_output = serialize_tool_payload(unwrapped)
             await self._finish_and_send(run_id)
         except Exception:

--- a/packages/orq-rc/src/orq_ai_sdk/langchain/_handler.py
+++ b/packages/orq-rc/src/orq_ai_sdk/langchain/_handler.py
@@ -359,7 +359,7 @@ class OrqLangchainCallback(BaseCallbackHandler):
             # letting non-message Pydantic returns serialize structurally.
             unwrapped: Any = output
             if isinstance(output, BaseMessage):
-                unwrapped = output.content
+                unwrapped = getattr(output, "content", output)
             event.tool_output = serialize_tool_payload(unwrapped)
             self._finish_and_send(run_id)
         except Exception:


### PR DESCRIPTION
To fix build errors in release here https://github.com/orq-ai/orq-python/actions/runs/25859043194

<img width="1519" height="770" alt="2026-05-14_21-32" src="https://github.com/user-attachments/assets/51025b34-344b-4cfc-b886-29256154b56c" />


Pyright could not narrow `output` to `BaseMessage` inside the `isinstance` branch because BaseMessage is imported with `# type: ignore`, leaving `output` typed as `str` from the LangChain interface signature and tripping reportAttributeAccessIssue on `.content`.