### PR TITLE
Fix pyright error on BaseMessage.content access in langchain handlers

### DIFF
--- a/src/orq_ai_sdk/langchain/_async_handler.py
+++ b/src/orq_ai_sdk/langchain/_async_handler.py
@@ -342,7 +342,7 @@ class AsyncOrqLangchainCallback(AsyncCallbackHandler):
             # letting non-message Pydantic returns serialize structurally.
             unwrapped: Any = output
             if isinstance(output, BaseMessage):
-                unwrapped = output.content
+                unwrapped = getattr(output, "content", output)
             event.tool_output = serialize_tool_payload(unwrapped)
             await self._finish_and_send(run_id)
         except Exception:

--- a/src/orq_ai_sdk/langchain/_handler.py
+++ b/src/orq_ai_sdk/langchain/_handler.py
@@ -359,7 +359,7 @@ class OrqLangchainCallback(BaseCallbackHandler):
             # letting non-message Pydantic returns serialize structurally.
             unwrapped: Any = output
             if isinstance(output, BaseMessage):
-                unwrapped = output.content
+                unwrapped = getattr(output, "content", output)
             event.tool_output = serialize_tool_payload(unwrapped)
             self._finish_and_send(run_id)
         except Exception:


### PR DESCRIPTION
Production pipeline is failing here:
- https://github.com/orq-ai/orq-python/actions/runs/26107573577
- https://github.com/orq-ai/orq-python/actions/runs/26125989670

The on_tool_end callback's `output` parameter is typed as `str` per LangChain's signature, but at runtime can be a BaseMessage. Pyright flagged the direct `.content` access inside the isinstance guard. Switch to `getattr(output, "content", output)` to match the fix already applied in packages/orq-rc.