### PR TITLE
fix(deps): relax requests pin to >=2.33.0 (CVE-2026-25645)

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -38,7 +38,7 @@ python:
       opentelemetry-sdk: ^1.20.0
       types-requests: ^2.32.4.20250809
     main:
-      requests: ==2.32.4
+      requests: '>=2.33.0,<3.0.0'
   allowedRedefinedBuiltins:
     - id
     - object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "httpcore >=1.0.9",
     "httpx >=0.28.1",
     "pydantic >=2.11.2",
-    "requests ==2.32.4",
+    "requests >=2.33.0,<3.0.0",
 ]
 urls.repository = "https://github.com/orq-ai/orq-python.git"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -769,7 +769,7 @@ requires-dist = [
     { name = "httpcore", specifier = ">=1.0.9" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.11.2" },
-    { name = "requests", specifier = "==2.32.4" },
+    { name = "requests", specifier = ">=2.33.0,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1060,7 +1060,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1068,9 +1068,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`requests` was pinned `==2.32.4`, which carries **CVE-2026-25645** (`GHSA-gc5v-m9x4-r6x2`, medium / CVSS 4.4) — insecure temp file reuse in `requests.utils.extract_zipped_paths()`. The exact pin blocks any downstream consumer (e.g. `evaluatorq`) from resolving the patched line, so the alert can't be cleared anywhere.

## Fix

Relax the pin to `>=2.33.0,<3.0.0` so the patched line resolves (locks to **2.34.2**).

- `.speakeasy/gen.yaml` — source of truth for the Speakeasy-generated SDK
- `pyproject.toml` — mirrored so it's correct until the next regen
- `uv.lock` — relocked

## Compatibility

Only `requests.post(...)` is used (`src/orq_ai_sdk/traced/client.py:115`) — a stable core API, fully compatible with 2.34.x. `extract_zipped_paths` is never called.

## Testing

`uv run --with pytest --with pytest-asyncio pytest` → **33 passed, 4 skipped**.

## Notes

- `poetry.lock` left untouched — it's stale legacy (Speakeasy moved to uv; last poetry regen was Jan). Will be reconciled on the next Speakeasy regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)