### PR TITLE
fix(ENG-1983): discriminator crash on UNSET/type-less union fields

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,0 +1,4 @@
+# Preserve the ENG-1983 local fix (get_discriminator returns None instead of
+# raising). Upstream Speakeasy still raises; do not let regen revert this.
+# Remove this entry once the fix lands upstream and the CLI/template is bumped.
+src/orq_ai_sdk/utils/annotations.py

--- a/src/orq_ai_sdk/utils/annotations.py
+++ b/src/orq_ai_sdk/utils/annotations.py
@@ -79,6 +79,6 @@ def get_discriminator(model: Any, fieldname: str, key: str) -> Optional[str]:
     # ENG-1983: return None instead of raising so pydantic treats an absent
     # discriminator (UNSET / type-less values) as a soft per-branch miss and
     # falls through to the None/UNSET arm of the union, rather than aborting
-    # model construction. Upstream Speakeasy raises here; this is a persisted
-    # local edit (see .speakeasy/gen.lock persistentEdits).
+    # model construction. Upstream Speakeasy raises here; this file is frozen
+    # against regen via .genignore so the edit is not reverted.
     return None

--- a/src/orq_ai_sdk/utils/annotations.py
+++ b/src/orq_ai_sdk/utils/annotations.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Optional
 
 
-def get_discriminator(model: Any, fieldname: str, key: str) -> str:
+def get_discriminator(model: Any, fieldname: str, key: str) -> Optional[str]:
     """
     Recursively search for the discriminator attribute in a model.
 
@@ -76,4 +76,9 @@ def get_discriminator(model: Any, fieldname: str, key: str) -> str:
     if discriminator is not None:
         return discriminator
 
-    raise ValueError(f"Could not find discriminator field {fieldname} in {model}")
+    # ENG-1983: return None instead of raising so pydantic treats an absent
+    # discriminator (UNSET / type-less values) as a soft per-branch miss and
+    # falls through to the None/UNSET arm of the union, rather than aborting
+    # model construction. Upstream Speakeasy raises here; this is a persisted
+    # local edit (see .speakeasy/gen.lock persistentEdits).
+    return None

--- a/tests/test_eval_discriminator.py
+++ b/tests/test_eval_discriminator.py
@@ -1,0 +1,45 @@
+"""Regression test for ENG-1983 / ENG-1982 / ENG-2002.
+
+A discriminated-union field that is UNSET or type-less must NOT raise at
+model construction. Lives outside the Speakeasy-managed file set so it
+survives regeneration.
+"""
+
+import pytest
+from pydantic import TypeAdapter
+
+from orq_ai_sdk import models
+from orq_ai_sdk.models.updateevalop import GuardrailConfig
+from orq_ai_sdk.types import UNSET
+
+
+def test_update_eval_body_with_unset_guardrail_config():
+    """ENG-1983: omitted/UNSET guardrail_config must construct cleanly."""
+    body = models.UpdateEvalRequestBody(type=None, prompt="hi", guardrail_config=UNSET)
+    # Unset is a pydantic model copied on validation, so compare by type, not identity.
+    assert isinstance(body.guardrail_config, type(UNSET))
+
+
+def test_update_eval_body_without_guardrail_config():
+    """Baseline: field fully omitted (was already passing)."""
+    body = models.UpdateEvalRequestBody(type=None, prompt="hi")
+    assert isinstance(body.guardrail_config, type(UNSET))
+
+
+def test_valid_guardrail_config_still_discriminates():
+    """Guard against over-fixing: a real, typed union value must still resolve
+    to the correct member rather than silently falling through."""
+    cfg = TypeAdapter(GuardrailConfig).validate_python(
+        {"type": "number", "value": 0.5, "operator": "gte"}
+    )
+    assert cfg.type == "number"
+    assert cfg.value == 0.5
+
+
+def test_typeless_guardrail_dict_does_not_crash_construction():
+    """ENG-2002 shape: a type-less dict must raise pydantic's ValidationError
+    (a clean union mismatch), NOT a raw ValueError out of the discriminator."""
+    with pytest.raises(Exception) as exc:
+        TypeAdapter(GuardrailConfig).validate_python({})
+    # Must be pydantic validation, not the discriminator's ValueError.
+    assert "Could not find discriminator field" not in str(exc.value)


### PR DESCRIPTION
## Problem

`orq.evals.update(id=..., <any field>)` raised `ValueError: Could not find discriminator field type` at construction, **before any HTTP call** — making every Python evaluator update unusable. `guardrail_config` defaults to the `UNSET` sentinel and is fed into a discriminated union whose discriminator callable raised on the type-less sentinel instead of returning `None`.

## Fix

`get_discriminator` returns `None` instead of raising when no discriminator is found, so pydantic falls through to the `None`/`UNSET` arm of the union.

`orq.evals.update(id="any-id", prompt="hi")` (fake key):
- **Before:** `ValueError: Could not find discriminator field type`
- **After:** reaches the server → `401`. Crash gone.

Closes **ENG-1983**, **ENG-1982**, **ENG-2002** — same root cause.

## Notes

- `annotations.py` is Speakeasy-managed; added to `.genignore` so regen won't revert it (upstream still raises). Not exercised locally — confirm with a `speakeasy run` before publishing.
- Regression test in `tests/` (survives regen). Suite: 37 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)