### PR TITLE
Add function tool helpers for Responses requests

### DIFF
--- a/packages/orq-rc/src/orq_ai_sdk/function_tools.py
+++ b/packages/orq-rc/src/orq_ai_sdk/function_tools.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import dataclasses
 import enum
 import functools
 import inspect
+import re
 import types
+import warnings
 from collections.abc import Callable, Iterator, Mapping
 from typing import Any, Literal, TypeVar, Union, cast, get_args, get_origin, get_type_hints, overload
 
@@ -18,6 +21,9 @@ _SUPPORTED_SCALAR_TYPES: dict[type[Any], str] = {
     bool: "boolean",
 }
 
+# Function-calling APIs constrain tool names to this character set.
+_VALID_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+
 
 class ToolSchemaError(TypeError):
     """Raised when a Python callable cannot be converted into a Responses function tool."""
@@ -27,13 +33,27 @@ class ToolFunctionWrapper(Mapping[str, Any]):
     """Callable wrapper that also exposes a Mapping payload accepted by the SDK `tools=` field."""
 
     def __init__(self, func: Callable[..., Any], schema: ToolsFunction) -> None:
-        self._func = func
+        # If re-wrapping an existing tool, point at the underlying function so we
+        # don't nest wrappers. `updated=()` stops update_wrapper from copying
+        # __dict__, which would otherwise clobber the _schema we just set.
+        target = func.raw_function if isinstance(func, ToolFunctionWrapper) else func
+        functools.update_wrapper(self, target, updated=())
+        self._func = target
         self._schema = schema
         self._payload = schema.model_dump(mode="json", exclude_none=True)
-        functools.update_wrapper(self, func)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self._func(*args, **kwargs)
+
+    def __eq__(self, other: object) -> bool:
+        # Identity semantics: two tools that happen to share a schema are still
+        # different tools (different callables), so they must not compare equal.
+        return self is other
+
+    def __hash__(self) -> int:
+        # Restore hashability that Mapping disables (`__hash__ = None`); consistent
+        # with the identity __eq__ above.
+        return id(self)
 
     def __getitem__(self, key: str) -> Any:
         return self._payload[key]
@@ -66,7 +86,7 @@ class ToolFunctionWrapper(Mapping[str, Any]):
 
     @property
     def parameters(self) -> dict[str, Any]:
-        return dict(self._schema.parameters)
+        return dict(self._schema.parameters or {})
 
     @property
     def strict(self) -> bool | None:
@@ -100,7 +120,26 @@ def tool(
     """Decorate a callable so it can be passed directly as `tools=[my_tool]`.
 
     The wrapped object remains callable, but also behaves like a `Mapping`
-    containing the JSON payload for a Responses `type="function"` tool.
+    containing the JSON payload for a Responses `type="function"` tool. The
+    schema is derived from the function's name, docstring and type hints.
+
+    Args:
+        name: Override the tool name. Defaults to the function name.
+        description: Override the tool description. Defaults to the docstring.
+        strict: Emit a strict schema (`additionalProperties: false`). Defaults to True.
+
+    Usage:
+        @tool
+        def get_weather(city: str) -> str:
+            \"\"\"Return the weather for a city.\"\"\"
+            ...
+
+        # Override name/description
+        @tool(name="weather", description="Look up the weather")
+        def get_weather(city: str) -> str:
+            ...
+
+        response = client.responses.create(model=..., tools=[get_weather])
     """
 
     def decorator(inner: F) -> ToolFunctionWrapper:
@@ -127,35 +166,103 @@ def tool_schema(
     description: str | None = None,
     strict: bool = True,
 ) -> ToolsFunction:
-    """Convert a Python callable into a Responses `ToolsFunction` schema."""
+    """Convert a Python callable into a Responses `ToolsFunction` schema.
+
+    Use this when you need the schema object itself rather than a callable
+    wrapper. `@tool` calls this internally.
+
+    Args:
+        func: The callable (or an existing `@tool` wrapper) to introspect.
+        name: Override the tool name. Defaults to the function name.
+        description: Override the tool description. Defaults to the docstring.
+        strict: Emit a strict schema (`additionalProperties: false`). Defaults to True.
+
+    Raises:
+        ToolSchemaError: If the signature uses an unsupported parameter kind or
+            an annotation that cannot be mapped to a JSON schema.
+    """
 
     if isinstance(func, ToolFunctionWrapper):
-        if name is None and description is None:
-            return func.as_tools_function()
+        existing = func.as_tools_function()
+        if name is None and description is None and strict == existing.strict:
+            return existing
+        # Carry forward the decorator-provided name/description that aren't being
+        # overridden, so re-deriving from the raw function doesn't drop them.
+        name = name if name is not None else existing.name
+        description = description if description is not None else existing.description
         func = func.raw_function
 
     if not callable(func):
         raise ToolSchemaError(f"Expected a callable, got {type(func).__name__!r}.")
 
-    signature = inspect.signature(func)
-    type_hints = get_type_hints(func, include_extras=True)
+    display_name = getattr(func, "__name__", repr(func))
+
+    if inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func):
+        raise ToolSchemaError(
+            f"{display_name!r} is async; async tool functions are not supported. "
+            "Wrap the call in a synchronous function."
+        )
+
+    try:
+        signature = inspect.signature(func)
+        type_hints = get_type_hints(func, include_extras=True)
+    except (TypeError, NameError) as exc:
+        raise ToolSchemaError(
+            f"Could not introspect {display_name!r}: {exc}. functools.partial, "
+            "builtins, and locally-scoped annotations are not supported."
+        ) from exc
 
     properties: dict[str, Any] = {}
     required: list[str] = []
-    for parameter in signature.parameters.values():
+    defaulted_params: list[str] = []
+    for index, parameter in enumerate(signature.parameters.values()):
+        # Skip the implicit receiver of a method decorated directly with @tool.
+        if index == 0 and parameter.name in ("self", "cls"):
+            continue
+
         _validate_parameter(parameter)
 
         if parameter.name not in type_hints:
             raise ToolSchemaError(
-                f"Parameter {parameter.name!r} on {func.__name__!r} is missing a type annotation."
+                f"Parameter {parameter.name!r} on {display_name!r} is missing a type annotation."
             )
 
         annotation = type_hints[parameter.name]
-        properties[parameter.name] = _annotation_to_schema(annotation)
-        if parameter.default is inspect.Signature.empty:
+        schema = _annotation_to_schema(annotation)
+        has_default = parameter.default is not inspect.Signature.empty
+        # Only warn about defaults the model can't reach: a `None` default round-trips
+        # perfectly (the model sends null → the function receives None), so it isn't lost.
+        if has_default and parameter.default is not None:
+            defaulted_params.append(parameter.name)
+        if has_default and strict:
+            # OpenAI strict function-calling requires every property to appear in
+            # `required`; optionality is expressed by making the field nullable.
+            # (Non-strict schemas may simply omit the key from `required`.)
+            schema = _make_nullable(schema)
+        properties[parameter.name] = schema
+        if strict or not has_default:
             required.append(parameter.name)
 
-    function_name = name or func.__name__
+    function_name = name or getattr(func, "__name__", None)
+    if not function_name:
+        raise ToolSchemaError("Callable has no __name__; pass an explicit name=.")
+    if not _VALID_TOOL_NAME.match(function_name):
+        raise ToolSchemaError(
+            f"Tool name {function_name!r} is invalid; names must match "
+            f"{_VALID_TOOL_NAME.pattern} (letters, digits, underscore, hyphen). "
+            "Pass an explicit name= for lambdas or other unnamed callables."
+        )
+
+    if strict and defaulted_params:
+        warnings.warn(
+            f"Tool {function_name!r} has parameters with defaults "
+            f"({', '.join(defaulted_params)}) but strict=True. Under strict "
+            "function-calling every parameter is required, so the model must send "
+            "a value (or null) and these Python defaults are likely ignored. Pass "
+            "strict=False to keep them optional.",
+            UserWarning,
+            stacklevel=2,
+        )
     function_description = description if description is not None else inspect.getdoc(func)
     return ToolsFunction(
         name=function_name,
@@ -188,7 +295,23 @@ def _validate_parameter(parameter: inspect.Parameter) -> None:
         )
 
 
+def _make_nullable(schema: dict[str, Any]) -> dict[str, Any]:
+    null_schema = {"type": "null"}
+    if "anyOf" in schema:
+        if null_schema in schema["anyOf"]:
+            return schema
+        return {"anyOf": [*schema["anyOf"], null_schema]}
+    return {"anyOf": [schema, null_schema]}
+
+
 def _annotation_to_schema(annotation: Any) -> dict[str, Any]:
+    # Unwrap Annotated[T, ...]; get_type_hints(include_extras=True) preserves the metadata.
+    if hasattr(annotation, "__metadata__"):
+        annotation = annotation.__origin__
+    # Unwrap NewType("X", int) to its supertype.
+    if hasattr(annotation, "__supertype__"):
+        annotation = annotation.__supertype__
+
     origin = get_origin(annotation)
 
     if annotation in _SUPPORTED_SCALAR_TYPES:
@@ -204,28 +327,53 @@ def _annotation_to_schema(annotation: Any) -> dict[str, Any]:
         values = list(get_args(annotation))
         if not values:
             raise ToolSchemaError("Literal annotations must declare at least one value.")
+        if None in values:
+            non_none = [value for value in values if value is not None]
+            if not non_none:
+                raise ToolSchemaError("Literal[None] is not a valid tool parameter type.")
+            return _make_nullable(_literal_to_schema(non_none))
         return _literal_to_schema(values)
 
-    if _is_optional_union(annotation):
-        non_none_args = [arg for arg in get_args(annotation) if arg is not type(None)]
+    if origin in (Union, types.UnionType):
+        args = get_args(annotation)
+        non_none_args = [arg for arg in args if arg is not type(None)]
         if len(non_none_args) != 1:
             raise ToolSchemaError(
-                "Only Optional[T] unions are supported. Nested or multi-branch unions are not."
+                "Only Optional[T] (a single type, optionally with None) is supported; "
+                "multi-branch unions are not."
             )
-        return {
-            "anyOf": [
-                _annotation_to_schema(non_none_args[0]),
-                {"type": "null"},
-            ],
-        }
+        inner = _annotation_to_schema(non_none_args[0])
+        return _make_nullable(inner) if type(None) in args else inner
 
     if inspect.isclass(annotation) and issubclass(annotation, enum.Enum):
         return _enum_to_schema(annotation)
+
+    if _is_model_like(annotation):
+        raise ToolSchemaError(
+            f"{annotation!r} is a Pydantic model or dataclass; nested object parameters "
+            "are not supported. Flatten it into scalar parameters."
+        )
+
+    if annotation in (list, dict, set, frozenset, tuple) or origin in (dict, tuple, set, frozenset):
+        raise ToolSchemaError(
+            f"Annotation {annotation!r} needs a parameterized item type (e.g. list[str]); "
+            "bare containers and dict/tuple/set are not supported."
+        )
 
     raise ToolSchemaError(
         f"Unsupported annotation {annotation!r}. "
         "Supported types are str, int, float, bool, list[T], Optional[T], Literal, and Enum."
     )
+
+
+def _is_model_like(annotation: Any) -> bool:
+    if dataclasses.is_dataclass(annotation):
+        return True
+    try:
+        from pydantic import BaseModel
+    except ImportError:
+        return False
+    return inspect.isclass(annotation) and issubclass(annotation, BaseModel)
 
 
 def _literal_to_schema(values: list[Any]) -> dict[str, Any]:
@@ -264,14 +412,6 @@ def _enum_to_schema(enum_type: type[enum.Enum]) -> dict[str, Any]:
         "type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], value_type)],
         "enum": values,
     }
-
-
-def _is_optional_union(annotation: Any) -> bool:
-    origin = get_origin(annotation)
-    if origin not in (Union, types.UnionType):
-        return False
-    args = get_args(annotation)
-    return any(arg is type(None) for arg in args)
 
 
 __all__ = [

--- a/packages/orq-rc/src/orq_ai_sdk/function_tools.py
+++ b/packages/orq-rc/src/orq_ai_sdk/function_tools.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import enum
+import functools
+import inspect
+import types
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any, Literal, TypeVar, Union, cast, get_args, get_origin, get_type_hints, overload
+
+from orq_ai_sdk.models.create_router_responseop import ToolsFunction
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_SUPPORTED_SCALAR_TYPES: dict[type[Any], str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+}
+
+
+class ToolSchemaError(TypeError):
+    """Raised when a Python callable cannot be converted into a Responses function tool."""
+
+
+class ToolFunctionWrapper(Mapping[str, Any]):
+    """Callable wrapper that also exposes a Mapping payload accepted by the SDK `tools=` field."""
+
+    def __init__(self, func: Callable[..., Any], schema: ToolsFunction) -> None:
+        self._func = func
+        self._schema = schema
+        self._payload = schema.model_dump(mode="json", exclude_none=True)
+        functools.update_wrapper(self, func)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._func(*args, **kwargs)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._payload[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._payload)
+
+    def __len__(self) -> int:
+        return len(self._payload)
+
+    @property
+    def schema(self) -> dict[str, Any]:
+        return dict(self._payload)
+
+    @property
+    def raw_function(self) -> Callable[..., Any]:
+        return self._func
+
+    @property
+    def type(self) -> str:
+        return self._schema.type
+
+    @property
+    def name(self) -> str:
+        return self._schema.name
+
+    @property
+    def description(self) -> str | None:
+        return self._schema.description
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return dict(self._schema.parameters)
+
+    @property
+    def strict(self) -> bool | None:
+        return self._schema.strict
+
+    def as_tools_function(self) -> ToolsFunction:
+        return self._schema
+
+
+@overload
+def tool(func: F, /) -> ToolFunctionWrapper: ...
+
+
+@overload
+def tool(
+    func: None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    strict: bool = True,
+) -> Callable[[F], ToolFunctionWrapper]: ...
+
+
+def tool(
+    func: F | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    strict: bool = True,
+) -> ToolFunctionWrapper | Callable[[F], ToolFunctionWrapper]:
+    """Decorate a callable so it can be passed directly as `tools=[my_tool]`.
+
+    The wrapped object remains callable, but also behaves like a `Mapping`
+    containing the JSON payload for a Responses `type="function"` tool.
+    """
+
+    def decorator(inner: F) -> ToolFunctionWrapper:
+        return ToolFunctionWrapper(
+            inner,
+            tool_schema(
+                inner,
+                name=name,
+                description=description,
+                strict=strict,
+            ),
+        )
+
+    if func is None:
+        return decorator
+
+    return decorator(func)
+
+
+def tool_schema(
+    func: Callable[..., Any] | ToolFunctionWrapper,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    strict: bool = True,
+) -> ToolsFunction:
+    """Convert a Python callable into a Responses `ToolsFunction` schema."""
+
+    if isinstance(func, ToolFunctionWrapper):
+        if name is None and description is None:
+            return func.as_tools_function()
+        func = func.raw_function
+
+    if not callable(func):
+        raise ToolSchemaError(f"Expected a callable, got {type(func).__name__!r}.")
+
+    signature = inspect.signature(func)
+    type_hints = get_type_hints(func, include_extras=True)
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for parameter in signature.parameters.values():
+        _validate_parameter(parameter)
+
+        if parameter.name not in type_hints:
+            raise ToolSchemaError(
+                f"Parameter {parameter.name!r} on {func.__name__!r} is missing a type annotation."
+            )
+
+        annotation = type_hints[parameter.name]
+        properties[parameter.name] = _annotation_to_schema(annotation)
+        if parameter.default is inspect.Signature.empty:
+            required.append(parameter.name)
+
+    function_name = name or func.__name__
+    function_description = description if description is not None else inspect.getdoc(func)
+    return ToolsFunction(
+        name=function_name,
+        type="function",
+        description=function_description,
+        parameters={
+            "type": "object",
+            "properties": properties,
+            "required": required,
+            "additionalProperties": False,
+        },
+        strict=strict,
+    )
+
+
+def _validate_parameter(parameter: inspect.Parameter) -> None:
+    if parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
+        raise ToolSchemaError(
+            f"Parameter {parameter.name!r} is positional-only; tool parameters must be named."
+        )
+
+    if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+        raise ToolSchemaError(
+            f"Parameter {parameter.name!r} uses *args, which is not supported for tool schemas."
+        )
+
+    if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+        raise ToolSchemaError(
+            f"Parameter {parameter.name!r} uses **kwargs, which is not supported for tool schemas."
+        )
+
+
+def _annotation_to_schema(annotation: Any) -> dict[str, Any]:
+    origin = get_origin(annotation)
+
+    if annotation in _SUPPORTED_SCALAR_TYPES:
+        return {"type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], annotation)]}
+
+    if origin is list:
+        args = get_args(annotation)
+        if len(args) != 1:
+            raise ToolSchemaError("list annotations must declare exactly one item type.")
+        return {"type": "array", "items": _annotation_to_schema(args[0])}
+
+    if origin is Literal:
+        values = list(get_args(annotation))
+        if not values:
+            raise ToolSchemaError("Literal annotations must declare at least one value.")
+        return _literal_to_schema(values)
+
+    if _is_optional_union(annotation):
+        non_none_args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(non_none_args) != 1:
+            raise ToolSchemaError(
+                "Only Optional[T] unions are supported. Nested or multi-branch unions are not."
+            )
+        return {
+            "anyOf": [
+                _annotation_to_schema(non_none_args[0]),
+                {"type": "null"},
+            ],
+        }
+
+    if inspect.isclass(annotation) and issubclass(annotation, enum.Enum):
+        return _enum_to_schema(annotation)
+
+    raise ToolSchemaError(
+        f"Unsupported annotation {annotation!r}. "
+        "Supported types are str, int, float, bool, list[T], Optional[T], Literal, and Enum."
+    )
+
+
+def _literal_to_schema(values: list[Any]) -> dict[str, Any]:
+    value_types = {type(value) for value in values}
+    if len(value_types) != 1:
+        raise ToolSchemaError("Literal values must all share the same scalar type.")
+
+    value_type = next(iter(value_types))
+    if value_type not in _SUPPORTED_SCALAR_TYPES:
+        raise ToolSchemaError(
+            "Literal values must be str, int, float, or bool for V1 tool schema support."
+        )
+
+    return {
+        "type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], value_type)],
+        "enum": values,
+    }
+
+
+def _enum_to_schema(enum_type: type[enum.Enum]) -> dict[str, Any]:
+    values = [member.value for member in enum_type]
+    if not values:
+        raise ToolSchemaError(f"Enum {enum_type.__name__!r} must declare at least one member.")
+
+    value_types = {type(value) for value in values}
+    if len(value_types) != 1:
+        raise ToolSchemaError(f"Enum {enum_type.__name__!r} must have homogenous value types.")
+
+    value_type = next(iter(value_types))
+    if value_type not in _SUPPORTED_SCALAR_TYPES:
+        raise ToolSchemaError(
+            f"Enum {enum_type.__name__!r} uses unsupported value type {value_type.__name__!r}."
+        )
+
+    return {
+        "type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], value_type)],
+        "enum": values,
+    }
+
+
+def _is_optional_union(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    if origin not in (Union, types.UnionType):
+        return False
+    args = get_args(annotation)
+    return any(arg is type(None) for arg in args)
+
+
+__all__ = [
+    "ToolFunctionWrapper",
+    "ToolSchemaError",
+    "tool",
+    "tool_schema",
+]

--- a/src/orq_ai_sdk/function_tools.py
+++ b/src/orq_ai_sdk/function_tools.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import dataclasses
 import enum
 import functools
 import inspect
+import re
 import types
+import warnings
 from collections.abc import Callable, Iterator, Mapping
 from typing import Any, Literal, TypeVar, Union, cast, get_args, get_origin, get_type_hints, overload
 
@@ -18,6 +21,9 @@ _SUPPORTED_SCALAR_TYPES: dict[type[Any], str] = {
     bool: "boolean",
 }
 
+# Function-calling APIs constrain tool names to this character set.
+_VALID_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+
 
 class ToolSchemaError(TypeError):
     """Raised when a Python callable cannot be converted into a Responses function tool."""
@@ -27,13 +33,27 @@ class ToolFunctionWrapper(Mapping[str, Any]):
     """Callable wrapper that also exposes a Mapping payload accepted by the SDK `tools=` field."""
 
     def __init__(self, func: Callable[..., Any], schema: ToolsFunction) -> None:
-        self._func = func
+        # If re-wrapping an existing tool, point at the underlying function so we
+        # don't nest wrappers. `updated=()` stops update_wrapper from copying
+        # __dict__, which would otherwise clobber the _schema we just set.
+        target = func.raw_function if isinstance(func, ToolFunctionWrapper) else func
+        functools.update_wrapper(self, target, updated=())
+        self._func = target
         self._schema = schema
         self._payload = schema.model_dump(mode="json", exclude_none=True)
-        functools.update_wrapper(self, func)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self._func(*args, **kwargs)
+
+    def __eq__(self, other: object) -> bool:
+        # Identity semantics: two tools that happen to share a schema are still
+        # different tools (different callables), so they must not compare equal.
+        return self is other
+
+    def __hash__(self) -> int:
+        # Restore hashability that Mapping disables (`__hash__ = None`); consistent
+        # with the identity __eq__ above.
+        return id(self)
 
     def __getitem__(self, key: str) -> Any:
         return self._payload[key]
@@ -66,7 +86,7 @@ class ToolFunctionWrapper(Mapping[str, Any]):
 
     @property
     def parameters(self) -> dict[str, Any]:
-        return dict(self._schema.parameters)
+        return dict(self._schema.parameters or {})
 
     @property
     def strict(self) -> bool | None:
@@ -100,7 +120,26 @@ def tool(
     """Decorate a callable so it can be passed directly as `tools=[my_tool]`.
 
     The wrapped object remains callable, but also behaves like a `Mapping`
-    containing the JSON payload for a Responses `type="function"` tool.
+    containing the JSON payload for a Responses `type="function"` tool. The
+    schema is derived from the function's name, docstring and type hints.
+
+    Args:
+        name: Override the tool name. Defaults to the function name.
+        description: Override the tool description. Defaults to the docstring.
+        strict: Emit a strict schema (`additionalProperties: false`). Defaults to True.
+
+    Usage:
+        @tool
+        def get_weather(city: str) -> str:
+            \"\"\"Return the weather for a city.\"\"\"
+            ...
+
+        # Override name/description
+        @tool(name="weather", description="Look up the weather")
+        def get_weather(city: str) -> str:
+            ...
+
+        response = client.responses.create(model=..., tools=[get_weather])
     """
 
     def decorator(inner: F) -> ToolFunctionWrapper:
@@ -127,35 +166,103 @@ def tool_schema(
     description: str | None = None,
     strict: bool = True,
 ) -> ToolsFunction:
-    """Convert a Python callable into a Responses `ToolsFunction` schema."""
+    """Convert a Python callable into a Responses `ToolsFunction` schema.
+
+    Use this when you need the schema object itself rather than a callable
+    wrapper. `@tool` calls this internally.
+
+    Args:
+        func: The callable (or an existing `@tool` wrapper) to introspect.
+        name: Override the tool name. Defaults to the function name.
+        description: Override the tool description. Defaults to the docstring.
+        strict: Emit a strict schema (`additionalProperties: false`). Defaults to True.
+
+    Raises:
+        ToolSchemaError: If the signature uses an unsupported parameter kind or
+            an annotation that cannot be mapped to a JSON schema.
+    """
 
     if isinstance(func, ToolFunctionWrapper):
-        if name is None and description is None:
-            return func.as_tools_function()
+        existing = func.as_tools_function()
+        if name is None and description is None and strict == existing.strict:
+            return existing
+        # Carry forward the decorator-provided name/description that aren't being
+        # overridden, so re-deriving from the raw function doesn't drop them.
+        name = name if name is not None else existing.name
+        description = description if description is not None else existing.description
         func = func.raw_function
 
     if not callable(func):
         raise ToolSchemaError(f"Expected a callable, got {type(func).__name__!r}.")
 
-    signature = inspect.signature(func)
-    type_hints = get_type_hints(func, include_extras=True)
+    display_name = getattr(func, "__name__", repr(func))
+
+    if inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func):
+        raise ToolSchemaError(
+            f"{display_name!r} is async; async tool functions are not supported. "
+            "Wrap the call in a synchronous function."
+        )
+
+    try:
+        signature = inspect.signature(func)
+        type_hints = get_type_hints(func, include_extras=True)
+    except (TypeError, NameError) as exc:
+        raise ToolSchemaError(
+            f"Could not introspect {display_name!r}: {exc}. functools.partial, "
+            "builtins, and locally-scoped annotations are not supported."
+        ) from exc
 
     properties: dict[str, Any] = {}
     required: list[str] = []
-    for parameter in signature.parameters.values():
+    defaulted_params: list[str] = []
+    for index, parameter in enumerate(signature.parameters.values()):
+        # Skip the implicit receiver of a method decorated directly with @tool.
+        if index == 0 and parameter.name in ("self", "cls"):
+            continue
+
         _validate_parameter(parameter)
 
         if parameter.name not in type_hints:
             raise ToolSchemaError(
-                f"Parameter {parameter.name!r} on {func.__name__!r} is missing a type annotation."
+                f"Parameter {parameter.name!r} on {display_name!r} is missing a type annotation."
             )
 
         annotation = type_hints[parameter.name]
-        properties[parameter.name] = _annotation_to_schema(annotation)
-        if parameter.default is inspect.Signature.empty:
+        schema = _annotation_to_schema(annotation)
+        has_default = parameter.default is not inspect.Signature.empty
+        # Only warn about defaults the model can't reach: a `None` default round-trips
+        # perfectly (the model sends null → the function receives None), so it isn't lost.
+        if has_default and parameter.default is not None:
+            defaulted_params.append(parameter.name)
+        if has_default and strict:
+            # OpenAI strict function-calling requires every property to appear in
+            # `required`; optionality is expressed by making the field nullable.
+            # (Non-strict schemas may simply omit the key from `required`.)
+            schema = _make_nullable(schema)
+        properties[parameter.name] = schema
+        if strict or not has_default:
             required.append(parameter.name)
 
-    function_name = name or func.__name__
+    function_name = name or getattr(func, "__name__", None)
+    if not function_name:
+        raise ToolSchemaError("Callable has no __name__; pass an explicit name=.")
+    if not _VALID_TOOL_NAME.match(function_name):
+        raise ToolSchemaError(
+            f"Tool name {function_name!r} is invalid; names must match "
+            f"{_VALID_TOOL_NAME.pattern} (letters, digits, underscore, hyphen). "
+            "Pass an explicit name= for lambdas or other unnamed callables."
+        )
+
+    if strict and defaulted_params:
+        warnings.warn(
+            f"Tool {function_name!r} has parameters with defaults "
+            f"({', '.join(defaulted_params)}) but strict=True. Under strict "
+            "function-calling every parameter is required, so the model must send "
+            "a value (or null) and these Python defaults are likely ignored. Pass "
+            "strict=False to keep them optional.",
+            UserWarning,
+            stacklevel=2,
+        )
     function_description = description if description is not None else inspect.getdoc(func)
     return ToolsFunction(
         name=function_name,
@@ -188,7 +295,23 @@ def _validate_parameter(parameter: inspect.Parameter) -> None:
         )
 
 
+def _make_nullable(schema: dict[str, Any]) -> dict[str, Any]:
+    null_schema = {"type": "null"}
+    if "anyOf" in schema:
+        if null_schema in schema["anyOf"]:
+            return schema
+        return {"anyOf": [*schema["anyOf"], null_schema]}
+    return {"anyOf": [schema, null_schema]}
+
+
 def _annotation_to_schema(annotation: Any) -> dict[str, Any]:
+    # Unwrap Annotated[T, ...]; get_type_hints(include_extras=True) preserves the metadata.
+    if hasattr(annotation, "__metadata__"):
+        annotation = annotation.__origin__
+    # Unwrap NewType("X", int) to its supertype.
+    if hasattr(annotation, "__supertype__"):
+        annotation = annotation.__supertype__
+
     origin = get_origin(annotation)
 
     if annotation in _SUPPORTED_SCALAR_TYPES:
@@ -204,28 +327,53 @@ def _annotation_to_schema(annotation: Any) -> dict[str, Any]:
         values = list(get_args(annotation))
         if not values:
             raise ToolSchemaError("Literal annotations must declare at least one value.")
+        if None in values:
+            non_none = [value for value in values if value is not None]
+            if not non_none:
+                raise ToolSchemaError("Literal[None] is not a valid tool parameter type.")
+            return _make_nullable(_literal_to_schema(non_none))
         return _literal_to_schema(values)
 
-    if _is_optional_union(annotation):
-        non_none_args = [arg for arg in get_args(annotation) if arg is not type(None)]
+    if origin in (Union, types.UnionType):
+        args = get_args(annotation)
+        non_none_args = [arg for arg in args if arg is not type(None)]
         if len(non_none_args) != 1:
             raise ToolSchemaError(
-                "Only Optional[T] unions are supported. Nested or multi-branch unions are not."
+                "Only Optional[T] (a single type, optionally with None) is supported; "
+                "multi-branch unions are not."
             )
-        return {
-            "anyOf": [
-                _annotation_to_schema(non_none_args[0]),
-                {"type": "null"},
-            ],
-        }
+        inner = _annotation_to_schema(non_none_args[0])
+        return _make_nullable(inner) if type(None) in args else inner
 
     if inspect.isclass(annotation) and issubclass(annotation, enum.Enum):
         return _enum_to_schema(annotation)
+
+    if _is_model_like(annotation):
+        raise ToolSchemaError(
+            f"{annotation!r} is a Pydantic model or dataclass; nested object parameters "
+            "are not supported. Flatten it into scalar parameters."
+        )
+
+    if annotation in (list, dict, set, frozenset, tuple) or origin in (dict, tuple, set, frozenset):
+        raise ToolSchemaError(
+            f"Annotation {annotation!r} needs a parameterized item type (e.g. list[str]); "
+            "bare containers and dict/tuple/set are not supported."
+        )
 
     raise ToolSchemaError(
         f"Unsupported annotation {annotation!r}. "
         "Supported types are str, int, float, bool, list[T], Optional[T], Literal, and Enum."
     )
+
+
+def _is_model_like(annotation: Any) -> bool:
+    if dataclasses.is_dataclass(annotation):
+        return True
+    try:
+        from pydantic import BaseModel
+    except ImportError:
+        return False
+    return inspect.isclass(annotation) and issubclass(annotation, BaseModel)
 
 
 def _literal_to_schema(values: list[Any]) -> dict[str, Any]:
@@ -264,14 +412,6 @@ def _enum_to_schema(enum_type: type[enum.Enum]) -> dict[str, Any]:
         "type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], value_type)],
         "enum": values,
     }
-
-
-def _is_optional_union(annotation: Any) -> bool:
-    origin = get_origin(annotation)
-    if origin not in (Union, types.UnionType):
-        return False
-    args = get_args(annotation)
-    return any(arg is type(None) for arg in args)
 
 
 __all__ = [

--- a/src/orq_ai_sdk/function_tools.py
+++ b/src/orq_ai_sdk/function_tools.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import enum
+import functools
+import inspect
+import types
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any, Literal, TypeVar, Union, cast, get_args, get_origin, get_type_hints, overload
+
+from orq_ai_sdk.models.create_router_responseop import ToolsFunction
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_SUPPORTED_SCALAR_TYPES: dict[type[Any], str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+}
+
+
+class ToolSchemaError(TypeError):
+    """Raised when a Python callable cannot be converted into a Responses function tool."""
+
+
+class ToolFunctionWrapper(Mapping[str, Any]):
+    """Callable wrapper that also exposes a Mapping payload accepted by the SDK `tools=` field."""
+
+    def __init__(self, func: Callable[..., Any], schema: ToolsFunction) -> None:
+        self._func = func
+        self._schema = schema
+        self._payload = schema.model_dump(mode="json", exclude_none=True)
+        functools.update_wrapper(self, func)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._func(*args, **kwargs)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._payload[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._payload)
+
+    def __len__(self) -> int:
+        return len(self._payload)
+
+    @property
+    def schema(self) -> dict[str, Any]:
+        return dict(self._payload)
+
+    @property
+    def raw_function(self) -> Callable[..., Any]:
+        return self._func
+
+    @property
+    def type(self) -> str:
+        return self._schema.type
+
+    @property
+    def name(self) -> str:
+        return self._schema.name
+
+    @property
+    def description(self) -> str | None:
+        return self._schema.description
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return dict(self._schema.parameters)
+
+    @property
+    def strict(self) -> bool | None:
+        return self._schema.strict
+
+    def as_tools_function(self) -> ToolsFunction:
+        return self._schema
+
+
+@overload
+def tool(func: F, /) -> ToolFunctionWrapper: ...
+
+
+@overload
+def tool(
+    func: None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    strict: bool = True,
+) -> Callable[[F], ToolFunctionWrapper]: ...
+
+
+def tool(
+    func: F | None = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    strict: bool = True,
+) -> ToolFunctionWrapper | Callable[[F], ToolFunctionWrapper]:
+    """Decorate a callable so it can be passed directly as `tools=[my_tool]`.
+
+    The wrapped object remains callable, but also behaves like a `Mapping`
+    containing the JSON payload for a Responses `type="function"` tool.
+    """
+
+    def decorator(inner: F) -> ToolFunctionWrapper:
+        return ToolFunctionWrapper(
+            inner,
+            tool_schema(
+                inner,
+                name=name,
+                description=description,
+                strict=strict,
+            ),
+        )
+
+    if func is None:
+        return decorator
+
+    return decorator(func)
+
+
+def tool_schema(
+    func: Callable[..., Any] | ToolFunctionWrapper,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    strict: bool = True,
+) -> ToolsFunction:
+    """Convert a Python callable into a Responses `ToolsFunction` schema."""
+
+    if isinstance(func, ToolFunctionWrapper):
+        if name is None and description is None:
+            return func.as_tools_function()
+        func = func.raw_function
+
+    if not callable(func):
+        raise ToolSchemaError(f"Expected a callable, got {type(func).__name__!r}.")
+
+    signature = inspect.signature(func)
+    type_hints = get_type_hints(func, include_extras=True)
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for parameter in signature.parameters.values():
+        _validate_parameter(parameter)
+
+        if parameter.name not in type_hints:
+            raise ToolSchemaError(
+                f"Parameter {parameter.name!r} on {func.__name__!r} is missing a type annotation."
+            )
+
+        annotation = type_hints[parameter.name]
+        properties[parameter.name] = _annotation_to_schema(annotation)
+        if parameter.default is inspect.Signature.empty:
+            required.append(parameter.name)
+
+    function_name = name or func.__name__
+    function_description = description if description is not None else inspect.getdoc(func)
+    return ToolsFunction(
+        name=function_name,
+        type="function",
+        description=function_description,
+        parameters={
+            "type": "object",
+            "properties": properties,
+            "required": required,
+            "additionalProperties": False,
+        },
+        strict=strict,
+    )
+
+
+def _validate_parameter(parameter: inspect.Parameter) -> None:
+    if parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
+        raise ToolSchemaError(
+            f"Parameter {parameter.name!r} is positional-only; tool parameters must be named."
+        )
+
+    if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+        raise ToolSchemaError(
+            f"Parameter {parameter.name!r} uses *args, which is not supported for tool schemas."
+        )
+
+    if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+        raise ToolSchemaError(
+            f"Parameter {parameter.name!r} uses **kwargs, which is not supported for tool schemas."
+        )
+
+
+def _annotation_to_schema(annotation: Any) -> dict[str, Any]:
+    origin = get_origin(annotation)
+
+    if annotation in _SUPPORTED_SCALAR_TYPES:
+        return {"type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], annotation)]}
+
+    if origin is list:
+        args = get_args(annotation)
+        if len(args) != 1:
+            raise ToolSchemaError("list annotations must declare exactly one item type.")
+        return {"type": "array", "items": _annotation_to_schema(args[0])}
+
+    if origin is Literal:
+        values = list(get_args(annotation))
+        if not values:
+            raise ToolSchemaError("Literal annotations must declare at least one value.")
+        return _literal_to_schema(values)
+
+    if _is_optional_union(annotation):
+        non_none_args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(non_none_args) != 1:
+            raise ToolSchemaError(
+                "Only Optional[T] unions are supported. Nested or multi-branch unions are not."
+            )
+        return {
+            "anyOf": [
+                _annotation_to_schema(non_none_args[0]),
+                {"type": "null"},
+            ],
+        }
+
+    if inspect.isclass(annotation) and issubclass(annotation, enum.Enum):
+        return _enum_to_schema(annotation)
+
+    raise ToolSchemaError(
+        f"Unsupported annotation {annotation!r}. "
+        "Supported types are str, int, float, bool, list[T], Optional[T], Literal, and Enum."
+    )
+
+
+def _literal_to_schema(values: list[Any]) -> dict[str, Any]:
+    value_types = {type(value) for value in values}
+    if len(value_types) != 1:
+        raise ToolSchemaError("Literal values must all share the same scalar type.")
+
+    value_type = next(iter(value_types))
+    if value_type not in _SUPPORTED_SCALAR_TYPES:
+        raise ToolSchemaError(
+            "Literal values must be str, int, float, or bool for V1 tool schema support."
+        )
+
+    return {
+        "type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], value_type)],
+        "enum": values,
+    }
+
+
+def _enum_to_schema(enum_type: type[enum.Enum]) -> dict[str, Any]:
+    values = [member.value for member in enum_type]
+    if not values:
+        raise ToolSchemaError(f"Enum {enum_type.__name__!r} must declare at least one member.")
+
+    value_types = {type(value) for value in values}
+    if len(value_types) != 1:
+        raise ToolSchemaError(f"Enum {enum_type.__name__!r} must have homogenous value types.")
+
+    value_type = next(iter(value_types))
+    if value_type not in _SUPPORTED_SCALAR_TYPES:
+        raise ToolSchemaError(
+            f"Enum {enum_type.__name__!r} uses unsupported value type {value_type.__name__!r}."
+        )
+
+    return {
+        "type": _SUPPORTED_SCALAR_TYPES[cast(type[Any], value_type)],
+        "enum": values,
+    }
+
+
+def _is_optional_union(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    if origin not in (Union, types.UnionType):
+        return False
+    args = get_args(annotation)
+    return any(arg is type(None) for arg in args)
+
+
+__all__ = [
+    "ToolFunctionWrapper",
+    "ToolSchemaError",
+    "tool",
+    "tool_schema",
+]

--- a/tests/test_function_tools.py
+++ b/tests/test_function_tools.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal, Optional
+
+import pytest
+
+from orq_ai_sdk import models, utils
+from orq_ai_sdk.function_tools import ToolFunctionWrapper, ToolSchemaError, tool, tool_schema
+from orq_ai_sdk.models.create_router_responseop import CreateRouterResponseRequestBody, ToolsFunction
+
+
+class Tone(str, Enum):
+    WARM = "warm"
+    COLD = "cold"
+
+
+def test_tool_decorator_uses_function_name_and_docstring():
+    @tool
+    def emit_magic_token(reason: str) -> str:
+        """Return a diagnostic token."""
+
+    schema = tool_schema(emit_magic_token).model_dump(mode="json", exclude_none=True)
+
+    assert schema == {
+        "name": "emit_magic_token",
+        "type": "function",
+        "description": "Return a diagnostic token.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "reason": {"type": "string"},
+            },
+            "required": ["reason"],
+            "additionalProperties": False,
+        },
+        "strict": True,
+    }
+
+
+def test_tool_empty_call_form_matches_bare_decorator():
+    @tool
+    def bare(reason: str) -> str:
+        """Bare decorator."""
+
+    @tool()
+    def called(reason: str) -> str:
+        """Called decorator."""
+
+    assert bare.schema["name"] == "bare"
+    assert bare.schema["description"] == "Bare decorator."
+    assert called.schema["name"] == "called"
+    assert called.schema["description"] == "Called decorator."
+    assert bare.schema["strict"] is True
+    assert called.schema["strict"] is True
+
+
+def test_tool_decorator_override_replaces_name_and_description():
+    @tool(name="custom_emit", description="Decorator override description.")
+    def emit_magic_token(reason: str) -> str:
+        """Original docstring."""
+
+    assert emit_magic_token.schema["name"] == "custom_emit"
+    assert emit_magic_token.schema["description"] == "Decorator override description."
+
+
+def test_tool_schema_override_can_rebuild_wrapped_function_schema():
+    @tool(name="decorated_name", description="Decorated description.")
+    def emit_magic_token(reason: str) -> str:
+        """Original docstring."""
+
+    overridden = tool_schema(
+        emit_magic_token,
+        name="runtime_override",
+        description="Runtime override description.",
+    ).model_dump(mode="json", exclude_none=True)
+
+    assert overridden["name"] == "runtime_override"
+    assert overridden["description"] == "Runtime override description."
+    assert overridden["strict"] is True
+
+
+def test_tool_schema_supports_optional_literal_enum_and_list():
+    def describe(
+        reason: str,
+        tags: list[str] | None = None,
+        mode: Literal["short", "long"] = "short",
+        tone: Tone = Tone.WARM,
+        retries: int = 1,
+        temperature: float = 0.5,
+        *,
+        enabled: bool = True,
+    ) -> str:
+        """Describe a request."""
+
+    schema = tool_schema(describe).model_dump(mode="json", exclude_none=True)
+    properties = schema["parameters"]["properties"]
+
+    assert properties["reason"] == {"type": "string"}
+    assert properties["tags"] == {
+        "anyOf": [
+            {"type": "array", "items": {"type": "string"}},
+            {"type": "null"},
+        ],
+    }
+    assert properties["mode"] == {"type": "string", "enum": ["short", "long"]}
+    assert properties["tone"] == {"type": "string", "enum": ["warm", "cold"]}
+    assert properties["retries"] == {"type": "integer"}
+    assert properties["temperature"] == {"type": "number"}
+    assert properties["enabled"] == {"type": "boolean"}
+    assert schema["parameters"]["required"] == ["reason"]
+
+
+def test_tool_schema_marks_only_parameters_without_defaults_as_required():
+    def emit_magic_token(reason: str, category: str, retries: int = 0) -> str:
+        """Return a token."""
+
+    schema = tool_schema(emit_magic_token).model_dump(mode="json", exclude_none=True)
+
+    assert schema["parameters"]["required"] == ["reason", "category"]
+
+
+def test_tool_wrapper_remains_callable_and_exposes_schema_attributes():
+    @tool
+    def emit_magic_token(reason: str) -> str:
+        """Return a diagnostic token."""
+
+        return f"magic:{reason}"
+
+    assert isinstance(emit_magic_token, ToolFunctionWrapper)
+    assert emit_magic_token("check") == "magic:check"
+    assert emit_magic_token.raw_function("check") == "magic:check"
+    assert emit_magic_token.__name__ == "emit_magic_token"
+    assert emit_magic_token.type == "function"
+    assert emit_magic_token.name == "emit_magic_token"
+    assert emit_magic_token.description == "Return a diagnostic token."
+    assert emit_magic_token.parameters == {
+        "type": "object",
+        "properties": {"reason": {"type": "string"}},
+        "required": ["reason"],
+        "additionalProperties": False,
+    }
+    assert emit_magic_token.strict is True
+
+
+def test_wrapped_tool_is_coerced_by_generated_sdk_tools_union():
+    @tool
+    def emit_magic_token(reason: str) -> str:
+        """Return a diagnostic token."""
+
+    coerced = utils.get_pydantic_model(
+        [emit_magic_token],
+        Optional[list[models.CreateRouterResponseTools]],
+    )
+
+    assert isinstance(coerced, list)
+    assert len(coerced) == 1
+    assert isinstance(coerced[0], ToolsFunction)
+    assert coerced[0].model_dump(mode="json", exclude_none=True) == emit_magic_token.schema
+
+
+def test_wrapped_tool_can_be_used_in_request_body_model():
+    @tool
+    def emit_magic_token(reason: str) -> str:
+        """Return a diagnostic token."""
+
+    request = CreateRouterResponseRequestBody(
+        model="google-ai/gemini-2.5-flash",
+        input="Call the tool.",
+        tools=[emit_magic_token],
+    )
+
+    assert request.model_dump(mode="json", exclude_none=True)["tools"] == [
+        emit_magic_token.schema,
+    ]
+
+
+def test_tool_schema_rejects_missing_parameter_annotations():
+    def emit_magic_token(reason, category: str) -> str:
+        """Return a diagnostic token."""
+
+    with pytest.raises(ToolSchemaError, match="missing a type annotation"):
+        tool_schema(emit_magic_token)
+
+
+def test_tool_schema_rejects_positional_only_parameters():
+    def emit_magic_token(reason: str, /) -> str:
+        """Return a diagnostic token."""
+
+    with pytest.raises(ToolSchemaError, match="positional-only"):
+        tool_schema(emit_magic_token)
+
+
+def test_tool_schema_rejects_var_args_and_var_kwargs():
+    def with_args(reason: str, *extras: str) -> str:
+        """Return a diagnostic token."""
+
+    def with_kwargs(reason: str, **metadata: str) -> str:
+        """Return a diagnostic token."""
+
+    with pytest.raises(ToolSchemaError, match="\\*args"):
+        tool_schema(with_args)
+
+    with pytest.raises(ToolSchemaError, match="\\*\\*kwargs"):
+        tool_schema(with_kwargs)
+
+
+def test_tool_schema_rejects_unsupported_annotations():
+    def emit_magic_token(metadata: dict[str, str]) -> str:
+        """Return a diagnostic token."""
+
+    with pytest.raises(ToolSchemaError, match="Unsupported annotation"):
+        tool_schema(emit_magic_token)

--- a/tests/test_function_tools.py
+++ b/tests/test_function_tools.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
+import warnings
+from dataclasses import dataclass
 from enum import Enum
-from typing import Literal, Optional
+from typing import Annotated, Literal, NewType, Optional
 
 import pytest
+from pydantic import BaseModel
 
 from orq_ai_sdk import models, utils
 from orq_ai_sdk.function_tools import ToolFunctionWrapper, ToolSchemaError, tool, tool_schema
@@ -13,6 +17,19 @@ from orq_ai_sdk.models.create_router_responseop import CreateRouterResponseReque
 class Tone(str, Enum):
     WARM = "warm"
     COLD = "cold"
+
+
+UserId = NewType("UserId", int)
+
+
+class GuestInfo(BaseModel):
+    name: str
+
+
+@dataclass
+class Point:
+    x: int
+    y: int
 
 
 def test_tool_decorator_uses_function_name_and_docstring():
@@ -93,7 +110,7 @@ def test_tool_schema_supports_optional_literal_enum_and_list():
     ) -> str:
         """Describe a request."""
 
-    schema = tool_schema(describe).model_dump(mode="json", exclude_none=True)
+    schema = tool_schema(describe, strict=False).model_dump(mode="json", exclude_none=True)
     properties = schema["parameters"]["properties"]
 
     assert properties["reason"] == {"type": "string"}
@@ -111,13 +128,109 @@ def test_tool_schema_supports_optional_literal_enum_and_list():
     assert schema["parameters"]["required"] == ["reason"]
 
 
-def test_tool_schema_marks_only_parameters_without_defaults_as_required():
+def test_non_strict_schema_marks_only_parameters_without_defaults_as_required():
     def emit_magic_token(reason: str, category: str, retries: int = 0) -> str:
         """Return a token."""
 
-    schema = tool_schema(emit_magic_token).model_dump(mode="json", exclude_none=True)
+    schema = tool_schema(emit_magic_token, strict=False).model_dump(mode="json", exclude_none=True)
 
     assert schema["parameters"]["required"] == ["reason", "category"]
+
+
+def test_strict_schema_requires_all_params_and_makes_defaulted_ones_nullable():
+    # OpenAI's strict function-calling spec 400s unless every property is in
+    # `required`; defaulted params must instead be expressed as nullable.
+    def emit_magic_token(reason: str, retries: int = 0, tags: list[str] | None = None) -> str:
+        """Return a token."""
+
+    schema = tool_schema(emit_magic_token).model_dump(mode="json", exclude_none=True)
+    props = schema["parameters"]["properties"]
+
+    assert schema["strict"] is True
+    assert schema["parameters"]["required"] == ["reason", "retries", "tags"]
+    assert props["reason"] == {"type": "string"}
+    assert props["retries"] == {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+    # Already-optional defaulted params don't get a duplicate null branch.
+    assert props["tags"] == {
+        "anyOf": [
+            {"type": "array", "items": {"type": "string"}},
+            {"type": "null"},
+        ],
+    }
+
+
+def test_strict_schema_warns_when_parameters_have_defaults():
+    def emit_magic_token(reason: str, retries: int = 0) -> str:
+        """Return a token."""
+
+    with pytest.warns(UserWarning, match="Python defaults are likely ignored") as record:
+        tool_schema(emit_magic_token)
+
+    assert "retries" in str(record[0].message)
+
+
+def test_non_strict_schema_does_not_warn_about_defaults(recwarn):
+    def emit_magic_token(reason: str, retries: int = 0) -> str:
+        """Return a token."""
+
+    tool_schema(emit_magic_token, strict=False)
+
+    assert not recwarn.list
+
+
+def test_strict_schema_without_defaults_does_not_warn(recwarn):
+    def emit_magic_token(reason: str) -> str:
+        """Return a token."""
+
+    tool_schema(emit_magic_token)
+
+    assert not recwarn.list
+
+
+def test_strict_schema_does_not_warn_for_none_default():
+    # An Optional param defaulting to None round-trips (model sends null -> None),
+    # so the default isn't lost and no warning should fire.
+    def emit_magic_token(reason: str, tags: list[str] | None = None) -> str:
+        """Return a token."""
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        tool_schema(emit_magic_token)
+
+
+def test_tool_schema_on_wrapper_respects_strict_override():
+    @tool  # strict=True by default
+    def emit_magic_token(reason: str, retries: int = 0) -> str:
+        """Return a token."""
+
+    reschema = tool_schema(emit_magic_token, strict=False)
+
+    assert reschema.strict is False
+    # strict=False drops defaulted params from `required` instead of nullable-ing them.
+    assert reschema.parameters["required"] == ["reason"]
+
+
+def test_annotated_parameters_are_unwrapped():
+    def emit_magic_token(reason: Annotated[str, "why"], retries: Annotated[int, "count"] = 0) -> str:
+        """Return a token."""
+
+    props = tool_schema(emit_magic_token, strict=False).model_dump(mode="json")["parameters"][
+        "properties"
+    ]
+
+    assert props["reason"] == {"type": "string"}
+    assert props["retries"] == {"type": "integer"}
+
+
+def test_tool_schema_on_wrapper_with_override_keeps_existing_description():
+    @tool(description="Custom decorator description.")
+    def emit_magic_token(reason: str) -> str:
+        """Docstring that should be ignored."""
+
+    reschema = tool_schema(emit_magic_token, name="renamed")
+
+    assert reschema.name == "renamed"
+    assert reschema.description == "Custom decorator description."
 
 
 def test_tool_wrapper_remains_callable_and_exposes_schema_attributes():
@@ -206,8 +319,156 @@ def test_tool_schema_rejects_var_args_and_var_kwargs():
 
 
 def test_tool_schema_rejects_unsupported_annotations():
-    def emit_magic_token(metadata: dict[str, str]) -> str:
+    def emit_magic_token(metadata: complex) -> str:
         """Return a diagnostic token."""
 
     with pytest.raises(ToolSchemaError, match="Unsupported annotation"):
         tool_schema(emit_magic_token)
+
+
+def test_bare_and_mapping_containers_give_clear_error():
+    def bare_list(items: list) -> str:
+        """Bare list."""
+
+    def mapping(m: dict[str, int]) -> str:
+        """Mapping."""
+
+    with pytest.raises(ToolSchemaError, match="parameterized item type"):
+        tool_schema(bare_list)
+    with pytest.raises(ToolSchemaError, match="parameterized item type"):
+        tool_schema(mapping)
+
+
+def test_async_functions_are_rejected():
+    async def emit_magic_token(reason: str) -> str:
+        """Async tool."""
+
+    with pytest.raises(ToolSchemaError, match="async"):
+        tool_schema(emit_magic_token)
+
+
+def test_partial_is_normalized_to_tool_schema_error():
+    from functools import partial
+
+    def base(a: int, b: int) -> int:
+        """Base."""
+        return a + b
+
+    with pytest.raises(ToolSchemaError):
+        tool_schema(partial(base, b=1))
+
+
+def test_method_self_parameter_is_skipped():
+    class Service:
+        @tool
+        def lookup(self, city: str) -> str:
+            """Look up a city."""
+            return city
+
+    assert Service.lookup.schema["parameters"]["required"] == ["city"]
+    assert "self" not in Service.lookup.schema["parameters"]["properties"]
+
+
+def test_lambda_name_is_rejected_but_explicit_name_works():
+    f = lambda city: city  # noqa: E731
+    f.__annotations__ = {"city": str, "return": str}
+
+    with pytest.raises(ToolSchemaError, match="invalid"):
+        tool_schema(f)
+
+    assert tool_schema(f, name="lookup").name == "lookup"
+
+
+def test_literal_with_none_becomes_nullable():
+    def describe(mode: Literal["short", "long", None] = None) -> str:
+        """Describe."""
+
+    props = tool_schema(describe, strict=False).model_dump(mode="json")["parameters"]["properties"]
+
+    assert props["mode"] == {
+        "anyOf": [{"type": "string", "enum": ["short", "long"]}, {"type": "null"}],
+    }
+
+
+def test_multi_branch_union_is_rejected():
+    def describe(value: int | str) -> str:
+        """Describe."""
+
+    with pytest.raises(ToolSchemaError, match="multi-branch"):
+        tool_schema(describe)
+
+
+def test_newtype_is_unwrapped_to_supertype():
+    def get(user: UserId) -> str:
+        """Get user."""
+
+    props = tool_schema(get).model_dump(mode="json")["parameters"]["properties"]
+
+    assert props["user"] == {"type": "integer"}
+
+
+def test_pydantic_and_dataclass_params_are_rejected_clearly():
+    def book(guest: GuestInfo) -> str:
+        """Book."""
+
+    def plot(point: Point) -> str:
+        """Plot."""
+
+    with pytest.raises(ToolSchemaError, match="Pydantic model or dataclass"):
+        tool_schema(book)
+    with pytest.raises(ToolSchemaError, match="Pydantic model or dataclass"):
+        tool_schema(plot)
+
+
+def test_wrapper_is_hashable_with_identity_semantics():
+    @tool(name="shared", description="Shared.")
+    def a(x: int) -> int:
+        """A."""
+        return x + 1
+
+    @tool(name="shared", description="Shared.")
+    def b(x: int) -> int:
+        """B."""
+        return x - 1
+
+    # Same schema payload, but different tools -> not equal, both hashable.
+    assert a.schema == b.schema
+    assert a != b
+    assert a == a
+    assert len({a, b}) == 2
+
+
+def test_redecorating_wrapper_applies_new_override():
+    @tool
+    def emit(reason: str) -> str:
+        """Original."""
+        return reason
+
+    redecorated = tool(name="outer", description="Outer desc.")(emit)
+
+    assert redecorated.schema["name"] == "outer"
+    assert redecorated.schema["description"] == "Outer desc."
+    assert redecorated("hi") == "hi"  # still points at the real function
+
+
+def test_wrapper_forwards_null_instead_of_applying_default():
+    @tool
+    def get_weather(city: str, units: str = "celsius") -> str:
+        """Weather."""
+        return f"{city}:{units}"
+
+    args = json.loads('{"city": "Paris", "units": null}')
+
+    # Under strict the model sends null; the Python default is NOT substituted.
+    assert get_weather(**args) == "Paris:None"
+
+
+def test_wrapper_applies_default_on_omission_under_non_strict():
+    @tool(strict=False)
+    def get_weather(city: str, units: str = "celsius") -> str:
+        """Weather."""
+        return f"{city}:{units}"
+
+    args = json.loads('{"city": "Paris"}')  # non-strict lets the model omit units
+
+    assert get_weather(**args) == "Paris:celsius"

--- a/tests/test_function_tools_live.py
+++ b/tests/test_function_tools_live.py
@@ -1,0 +1,88 @@
+"""Live integration tests for function tools over the orq.ai Responses API.
+
+These hit the real router, so they are skipped unless ORQ_API_KEY is set. They
+guard the strict-schema fix: a tool with a defaulted parameter must be accepted
+by OpenAI-routed models (which enforce OpenAI's strict function-calling spec and
+returned a 400 before the fix) as well as Gemini (which tolerated the old schema).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from orq_ai_sdk import Orq
+from orq_ai_sdk.function_tools import tool
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("ORQ_API_KEY"),
+    reason="ORQ_API_KEY not set; skipping live Responses API tests.",
+)
+
+# provider/model format expected by the router.
+MODELS = ["openai/gpt-4o", "google-ai/gemini-2.5-flash"]
+
+
+@tool
+def get_weather(city: str, units: str = "celsius") -> str:
+    """Return the current weather for a city.
+
+    `units` has a default, so under strict mode it is emitted as required +
+    nullable — the exact shape that used to 400 on OpenAI-routed models.
+    """
+    return f"20 degrees {units} in {city}"
+
+
+def test_defaulted_param_tool_is_accepted_across_providers():
+    # Sanity-check the schema we're about to send is the strict shape under test.
+    assert get_weather.schema["strict"] is True
+    assert "units" in get_weather.schema["parameters"]["required"]
+    assert get_weather.schema["parameters"]["properties"]["units"] == {
+        "anyOf": [{"type": "string"}, {"type": "null"}]
+    }
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_responses_api_accepts_defaulted_param_tool(model: str):
+    client = Orq(api_key=os.environ["ORQ_API_KEY"])
+
+    # Reaching a non-error response is the assertion: before the fix, openai/*
+    # rejected this tool schema with a 400 at request time.
+    response = client.responses.create(
+        model=model,
+        input="What is the weather in Paris? Use the get_weather tool.",
+        tools=[get_weather],
+    )
+
+    assert response is not None
+
+
+def test_pre_fix_schema_still_400s_on_openai():
+    """Regression guard: proves the live suite actually catches the original bug.
+
+    This is the schema shape the code produced before the fix — a defaulted param
+    omitted from `required` under strict=True. OpenAI-routed models reject it with a
+    400; if `_make_nullable`/required handling ever regresses to this shape, the
+    positive test above would start failing for the same reason.
+    """
+    client = Orq(api_key=os.environ["ORQ_API_KEY"])
+    pre_fix_tool = {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Return the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}, "units": {"type": "string"}},
+            "required": ["city"],  # units omitted -> invalid under strict
+            "additionalProperties": False,
+        },
+        "strict": True,
+    }
+
+    with pytest.raises(Exception, match="400"):
+        client.responses.create(
+            model="openai/gpt-4o",
+            input="What is the weather in Paris?",
+            tools=[pre_fix_tool],
+        )


### PR DESCRIPTION
## Summary
- add `orq_ai_sdk.function_tools` with `@tool` and `tool_schema(...)` helpers for request-scoped Responses function tools
- support `@tool`, `@tool()`, and `@tool(name=..., description=...)` so decorated callables can be passed directly as `tools=[my_tool]`
- validate the supported annotation subset locally and raise clear errors for unsupported signatures
- add focused unit coverage for schema generation, validation failures, generated SDK coercion, and direct request-body usage

## Example
```python
import os

from orq_ai_sdk import Orq
from orq_ai_sdk.function_tools import tool


@tool(name="emit_magic_token", description="Return a diagnostic token.")
def emit_magic_token(reason: str) -> str:
    """Original docstring."""


with Orq(api_key=os.getenv("ORQ_API_KEY", "")) as orq:
    response = orq.responses.create(
        model="google-ai/gemini-2.5-flash",
        input="Call emit_magic_token with a reason, then wait for the tool result.",
        tools=[emit_magic_token],
    )

    print(response.output)
```

## Notes
- this is intentionally an ergonomics layer only; it does not execute tools or run the `function_call_output` loop automatically
- the import surface stays explicit and regen-safe: `from orq_ai_sdk.function_tools import tool, tool_schema`

## Testing
- `uv run --with typing_extensions --with pytest-asyncio pytest tests/test_function_tools.py`
- verified `tools=[emit_magic_token]` with a plain `responses.create(...)` invocation against `google-ai/gemini-2.5-flash`
- verified the mirrored helper import path under `packages/orq-rc/src/orq_ai_sdk/function_tools.py`
