### PR TITLE
Add overlay to fix QueryParamMetadata type-name collision

### DIFF
--- a/.speakeasy/overlays/metadata-name-fix.yaml
+++ b/.speakeasy/overlays/metadata-name-fix.yaml
@@ -1,0 +1,17 @@
+overlay: 1.0.0
+info:
+  title: Avoid QueryParamMetadata type-name collision
+  version: 0.0.1
+# The listDatasources `metadata` query parameter is an inline object schema.
+# Without a title, Speakeasy names its generated type `QueryParamMetadata`,
+# which collides with the `QueryParamMetadata` class imported from
+# `orq_ai_sdk.utils` in the same module (listdatasourcesop.py), shadowing it
+# and breaking every `QueryParamMetadata(...)` call. Giving the schema an
+# explicit title makes Speakeasy generate `DatasourceMetadataFilter` instead.
+actions:
+  - target: $.paths["/v2/knowledge/{knowledge_id}/datasources"].get.parameters[?(@.name=="metadata")].schema
+    update:
+      title: DatasourceMetadataFilter
+  - target: $.paths["/v2/knowledge/{knowledge_id}/datasources"].get.parameters[?(@.name=="metadata")].schema.additionalProperties
+    update:
+      title: DatasourceMetadataValue

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -4,11 +4,15 @@ sources:
     orq-ai-sdk-prerelease-python:
         inputs:
             - location: ./openapi-prerelease.yaml
+        overlays:
+            - location: ./.speakeasy/overlays/metadata-name-fix.yaml
         registry:
             location: registry.speakeasyapi.dev/orq/orq/orq-ai-sdk-prerelease-python
     orq-ai-sdk-python:
         inputs:
             - location: ./openapi.yaml
+        overlays:
+            - location: ./.speakeasy/overlays/metadata-name-fix.yaml
         registry:
             location: registry.speakeasyapi.dev/orq/orq/orq-ai-sdk-python
 targets:


### PR DESCRIPTION
The listDatasources `metadata` query parameter is an inline object whose additionalProperties value union was generated as `QueryParamMetadata`, shadowing the `QueryParamMetadata` class imported from orq_ai_sdk.utils in listdatasourcesop.py and breaking type checking.

Add a Speakeasy overlay that titles the schema (DatasourceMetadataFilter) and its additionalProperties value (DatasourceMetadataValue), and wire it into both the prerelease and stable sources.

Prerelease pipeline is failing: 

<img width="1906" height="931" alt="2026-07-21_14-04_1" src="https://github.com/user-attachments/assets/22288edc-ada9-4764-8bb3-d901520b671e" />
<img width="1845" height="909" alt="2026-07-21_14-04" src="https://github.com/user-attachments/assets/e2e8c4ef-e31f-44c4-9055-a91972236557" />

After applying the fix

<img width="1840" height="1052" alt="2026-07-21_14-03" src="https://github.com/user-attachments/assets/769ae56d-4ebf-4569-a826-c99409058a56" />

only orq-python is affected on this issue and its working fine for orq-node.