### PR TITLE
ci: set Node heap limit for pyright via compileCommands

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -49,6 +49,14 @@ python:
   baseErrorName: OrqError
   bodyVariantOverloads: false
   clientServerStatusCodesAsErrors: true
+  compileCommands:
+    - ["uv", "lock"]
+    - ["uv", "run", "python", "scripts/prepare_readme.py"]
+    - ["uv", "sync", "--dev"]
+    - ["uv", "run", "python", "-m", "compileall", "-q", "."]
+    - ["uv", "run", "python", "-m", "mypy", "src/orq_ai_sdk"]
+    - ["uv", "run", "python", "-m", "pylint", "-j=0", "src/orq_ai_sdk"]
+    - ["env", "NODE_OPTIONS=--max-old-space-size=8192", "uv", "run", "python", "-m", "pyright", "src/orq_ai_sdk"]
   constFieldCasing: upper
   defaultErrorName: APIError
   description: Python Client SDK for the Orq API.

--- a/packages/orq-rc/.speakeasy/gen.yaml
+++ b/packages/orq-rc/.speakeasy/gen.yaml
@@ -49,6 +49,14 @@ python:
   baseErrorName: OrqError
   bodyVariantOverloads: false
   clientServerStatusCodesAsErrors: true
+  compileCommands:
+    - ["uv", "lock"]
+    - ["uv", "run", "python", "scripts/prepare_readme.py"]
+    - ["uv", "sync", "--dev"]
+    - ["uv", "run", "python", "-m", "compileall", "-q", "."]
+    - ["uv", "run", "python", "-m", "mypy", "src/orq_ai_sdk"]
+    - ["uv", "run", "python", "-m", "pylint", "-j=0", "src/orq_ai_sdk"]
+    - ["env", "NODE_OPTIONS=--max-old-space-size=8192", "uv", "run", "python", "-m", "pyright", "src/orq_ai_sdk"]
   constFieldCasing: upper
   defaultErrorName: APIError
   description: Python Client SDK for the Orq API.


### PR DESCRIPTION
New build of python sdk is failing due to the pyright which is using node running out of heap memory

<img width="1559" height="907" alt="2026-08-05_20-52" src="https://github.com/user-attachments/assets/b408faea-af39-4eef-b6f5-49ffb92d2d9f" />
<img width="1702" height="1012" alt="2026-08-05_20-51" src="https://github.com/user-attachments/assets/bfa9c0a8-84f8-4908-90c1-35b5babd8a3d" />
