### PR TITLE
fix(openai-agents): record tool call arguments on function spans (ENG-2642)

### DIFF
--- a/src/orq_ai_sdk/openai_agents_instrumentation/constants.py
+++ b/src/orq_ai_sdk/openai_agents_instrumentation/constants.py
@@ -14,6 +14,8 @@ class SpanAttributes(Enum):
     USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
     TOOL_NAME = "gen_ai.tool.name"
     TOOL_CALL_ID = "gen_ai.tool.call.id"
+    TOOL_CALL_ARGUMENTS = "gen_ai.tool.call.arguments"
+    TOOL_CALL_RESULT = "gen_ai.tool.call.result"
     GEN_AI_AGENT_NAME = "gen_ai.agent.name"
 
     # Orq custom attributes

--- a/src/orq_ai_sdk/openai_agents_instrumentation/processor.py
+++ b/src/orq_ai_sdk/openai_agents_instrumentation/processor.py
@@ -341,8 +341,14 @@ class EnhancedOpenAIAgentsProcessor(TracingProcessor):
             if data_id:
                 otel_span.set_attribute(SpanAttributes.TOOL_CALL_ID.value, data_id)
 
+        if data.input is not None:
+            arguments = data.input if isinstance(data.input, str) else str(data.input)
+            otel_span.set_attribute(SpanAttributes.TOOL_CALL_ARGUMENTS.value, arguments)
+
         if data.output is not None:
-            otel_span.set_attribute(SpanAttributes.OUTPUT_VALUE.value, str(data.output))
+            result = str(data.output)
+            otel_span.set_attribute(SpanAttributes.TOOL_CALL_RESULT.value, result)
+            otel_span.set_attribute(SpanAttributes.OUTPUT_VALUE.value, result)
 
     def _handle_handoff_span(self, otel_span: OtelSpan, data: HandoffSpanData) -> None:
         """Handle handoff span."""


### PR DESCRIPTION
FunctionSpanData.input carries the JSON argument string the Agents SDK hands to the processor, was removed in commit 63bc82ccf removed orq.input.value from every span type while adding canonical attributes. This PR follows the simillar direction

Before:
<img width="351" height="101" alt="image" src="https://github.com/user-attachments/assets/076358a7-1245-487e-a654-566f4390481b" />

After:
<img width="345" height="138" alt="image" src="https://github.com/user-attachments/assets/4b8dcfe8-7150-4d2d-b2b9-e8671976de1f" />


